### PR TITLE
fix: resolve serialization failure when calling call.end()

### DIFF
--- a/src/main/java/io/getstream/services/framework/StreamHTTPClient.java
+++ b/src/main/java/io/getstream/services/framework/StreamHTTPClient.java
@@ -2,6 +2,7 @@ package io.getstream.services.framework;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.util.StdDateFormat;
 import io.getstream.services.*;
 import io.jsonwebtoken.Jwts;
@@ -36,7 +37,8 @@ public class StreamHTTPClient {
               new StdDateFormat()
                   .withColonInTimeZone(true)
                   .withTimeZone(TimeZone.getTimeZone("UTC")))
-          .enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE);
+          .enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)
+          .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
 
   @NotNull private String apiSecret;
   @NotNull private String apiKey;

--- a/src/test/java/io/getstream/CallTest.java
+++ b/src/test/java/io/getstream/CallTest.java
@@ -257,6 +257,23 @@ public class CallTest extends BasicTest {
   }
 
   @Test
+  public void testEndCall() {
+    var callRequest =
+        GetOrCreateCallRequest.builder()
+            .data(CallRequest.builder().createdByID(testUser.getId()).build())
+            .build();
+
+    var callId = "call-" + RandomStringUtils.randomAlphabetic(10);
+    Assertions.assertDoesNotThrow(
+        () -> video.getOrCreateCall("default", callId, callRequest).execute());
+
+    Call call = video.call(callType, callId);
+
+    var response = Assertions.assertDoesNotThrow(() -> call.end());
+    Assertions.assertNotNull(response.getData().getDuration());
+  }
+
+  @Test
   void testSendCustomEvent() {
     Assertions.assertNotNull(testUser, "User should not be null");
     String callID = "call-" + RandomStringUtils.randomAlphanumeric(10);


### PR DESCRIPTION
Disable SerializationFeature.FAIL_ON_EMPTY_BEANS in ObjectMapper configuration to handle empty EndCallRequest objects. The previous configuration caused call.end() to fail with InvalidDefinitionException.

# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

Disables SerializationFeature.FAIL_ON_EMPTY_BEANS in ObjectMapper configuration to handle empty EndCallRequest objects. The previous configuration caused call.end() to fail with InvalidDefinitionException. Adds missing test.
