### PR TITLE
[FEEDS-1373] allow users to provide a custom OkHttpClient

### DIFF
--- a/src/main/java/io/getstream/services/framework/StreamHTTPClient.java
+++ b/src/main/java/io/getstream/services/framework/StreamHTTPClient.java
@@ -56,6 +56,14 @@ public class StreamHTTPClient {
     setCredetials(apiKey, apiSecret);
   }
 
+  public StreamHTTPClient(
+      @NotNull String apiKey, @NotNull String apiSecret, @NotNull OkHttpClient httpClient) {
+    this.apiKey = apiKey;
+    this.apiSecret = apiSecret;
+    var jwtToken = buildJWT(apiSecret);
+    this.client = buildHTTPClient(jwtToken, httpClient.newBuilder());
+  }
+
   // default constructor using ENV or System properties
   // env vars have priority over system properties
   public StreamHTTPClient() {
@@ -120,7 +128,13 @@ public class StreamHTTPClient {
     this.apiKey = apiKey;
     this.apiSecret = apiSecret;
     var jwtToken = buildJWT(apiSecret);
-    this.client = buildHTTPClient(jwtToken);
+    this.client = buildHTTPClient(jwtToken, defaultHttpClientBuilder());
+  }
+
+  private OkHttpClient.Builder defaultHttpClientBuilder() {
+    return new OkHttpClient.Builder()
+        .connectionPool(new ConnectionPool(5, 59, TimeUnit.SECONDS))
+        .callTimeout(timeout, TimeUnit.MILLISECONDS);
   }
 
   private void readPropertiesAndEnv(Properties properties) {
@@ -159,11 +173,7 @@ public class StreamHTTPClient {
     return HttpLoggingInterceptor.Level.valueOf(logLevel);
   }
 
-  private OkHttpClient buildHTTPClient(String jwtToken) {
-    OkHttpClient.Builder httpClient =
-        new OkHttpClient.Builder()
-            .connectionPool(new ConnectionPool(5, 59, TimeUnit.SECONDS))
-            .callTimeout(timeout, TimeUnit.MILLISECONDS);
+  private OkHttpClient buildHTTPClient(String jwtToken, OkHttpClient.Builder httpClient) {
     httpClient.interceptors().clear();
 
     HttpLoggingInterceptor loggingInterceptor =

--- a/src/main/java/io/getstream/services/framework/StreamSDKClient.java
+++ b/src/main/java/io/getstream/services/framework/StreamSDKClient.java
@@ -2,6 +2,7 @@ package io.getstream.services.framework;
 
 import io.getstream.services.*;
 import java.util.Properties;
+import okhttp3.OkHttpClient;
 import org.jetbrains.annotations.NotNull;
 
 public class StreamSDKClient extends CommonImpl implements Common {
@@ -17,6 +18,11 @@ public class StreamSDKClient extends CommonImpl implements Common {
 
   public StreamSDKClient(Properties properties) {
     this(new StreamHTTPClient(properties));
+  }
+
+  public StreamSDKClient(
+      @NotNull String apiKey, @NotNull String apiSecret, @NotNull OkHttpClient httpClient) {
+    this(new StreamHTTPClient(apiKey, apiSecret, httpClient));
   }
 
   public StreamSDKClient(StreamHTTPClient httpClient) {

--- a/src/test/java/io/getstream/StreamHTTPClientTest.java
+++ b/src/test/java/io/getstream/StreamHTTPClientTest.java
@@ -9,9 +9,13 @@ import io.getstream.models.TrackActivityMetricsEvent;
 import io.getstream.models.TrackActivityMetricsRequest;
 import io.getstream.models.UpdateAppRequest;
 import io.getstream.services.framework.StreamHTTPClient;
+import io.getstream.services.framework.StreamSDKClient;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import okhttp3.ConnectionPool;
+import okhttp3.OkHttpClient;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -133,6 +137,35 @@ public class StreamHTTPClientTest {
         json.contains("\"activity_id\":\"activity-123\""), "Expected activity ID in: " + json);
     assertTrue(json.contains("\"metric\":\"shares\""), "Expected custom metric in: " + json);
     assertTrue(json.contains("\"delta\":3"), "Expected delta in: " + json);
+  }
+
+  @Test
+  void testCustomOkHttpClientPreservesConfig() {
+    ConnectionPool customPool = new ConnectionPool(20, 120, TimeUnit.SECONDS);
+    OkHttpClient customHttp =
+        new OkHttpClient.Builder()
+            .connectionPool(customPool)
+            .connectTimeout(30, TimeUnit.SECONDS)
+            .readTimeout(45, TimeUnit.SECONDS)
+            .build();
+
+    var sdkClient =
+        new StreamSDKClient(
+            System.getenv("STREAM_API_KEY"), System.getenv("STREAM_API_SECRET"), customHttp);
+    OkHttpClient builtClient = sdkClient.getHttpClient().getHttpClient();
+
+    assertSame(customPool, builtClient.connectionPool());
+    assertEquals(30_000, builtClient.connectTimeoutMillis());
+    assertEquals(45_000, builtClient.readTimeoutMillis());
+
+    assertFalse(
+        builtClient.interceptors().isEmpty(), "SDK should add its interceptors to the client");
+  }
+
+  @Test
+  void testDefaultConstructorStillWorks() {
+    assertNotNull(client.getHttpClient());
+    assertFalse(client.getHttpClient().interceptors().isEmpty());
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Add new constructors on `StreamHTTPClient` and `StreamSDKClient` that accept a user-provided `OkHttpClient`, giving full control over connection pool, timeouts, proxy, SSL, and any other OkHttp setting.
- The SDK calls `client.newBuilder()` on the provided client, so the user's configuration is inherited while the SDK's required interceptors (auth, logging, headers) are still applied.
- Existing constructors are unchanged — fully backward-compatible.

**Usage:**
```java
OkHttpClient customClient = new OkHttpClient.Builder()
    .connectionPool(new ConnectionPool(10, 120, TimeUnit.SECONDS))
    .connectTimeout(30, TimeUnit.SECONDS)
    .proxy(myProxy)
    .build();

var client = new StreamSDKClient(apiKey, apiSecret, customClient);
```

## Test plan
- [ ] Verify all existing constructors still work as before
- [ ] Create an `OkHttpClient` with a custom connection pool and pass it to `new StreamSDKClient(key, secret, client)` — confirm the pool config is inherited
- [ ] Confirm SDK interceptors (auth header, api_key param, X-Stream-Client header) are present on outgoing requests
- [ ] Confirm logging interceptor is applied at default level


Made with [Cursor](https://cursor.com)