### PR TITLE
Fix duplicate usernames in visibility follow test

### DIFF
--- a/src/test/java/io/getstream/FeedIntegrationTests.java
+++ b/src/test/java/io/getstream/FeedIntegrationTests.java
@@ -1626,24 +1626,29 @@ class FeedIntegrationTests {
         "visibility-follower-a-" + RandomStringUtils.randomAlphanumeric(8);
     String rejectedFollowerUserId =
         "visibility-follower-r-" + RandomStringUtils.randomAlphanumeric(8);
+    String uniqueNameSuffix = RandomStringUtils.randomAlphanumeric(8);
 
     // snippet-start: JavaFollowersVisibilityFollowRequests
     Map<String, UserRequest> users = new HashMap<>();
     users.put(
         ownerUserId,
-        UserRequest.builder().id(ownerUserId).name("Visibility Owner").role("user").build());
+        UserRequest.builder()
+            .id(ownerUserId)
+            .name("Visibility Owner " + uniqueNameSuffix)
+            .role("user")
+            .build());
     users.put(
         acceptedFollowerUserId,
         UserRequest.builder()
             .id(acceptedFollowerUserId)
-            .name("Accepted Follower")
+            .name("Accepted Follower " + uniqueNameSuffix)
             .role("user")
             .build());
     users.put(
         rejectedFollowerUserId,
         UserRequest.builder()
             .id(rejectedFollowerUserId)
-            .name("Rejected Follower")
+            .name("Rejected Follower " + uniqueNameSuffix)
             .role("user")
             .build());
     client.updateUsers(UpdateUsersRequest.builder().users(users).build()).execute();


### PR DESCRIPTION
## Summary
- make `test39_FollowRequestsWithFollowersVisibility` append a random suffix to created usernames
- prevent CI collisions against persistent backend state where fixed usernames may already exist
- keep test behavior unchanged while removing rerun failures caused by duplicate username errors

## Test plan
- [x] `./gradlew test --tests "*FeedIntegrationTests.test39_FollowRequestsWithFollowersVisibility" --rerun-tasks`
- [x] rerun target test 3 additional times locally
- [x] confirm CI failure signature was duplicate usernames in `UpdateUsers`


Made with [Cursor](https://cursor.com)