### PR TITLE
[CHA-2956] connection pooling: stream-sdk-java

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,15 @@ All notable changes to this project will be documented in this file. See [standa
 - Webhook handling spec helpers (CHA-2961): `UnknownEvent` class for forward-compat;
   `gunzipPayload`, `decodeSqsPayload`, `decodeSnsPayload` primitives;
   `verifyAndParseWebhook` HTTP composite; `parseSqs` / `parseSns`
-  queue composites (no HMAC signature on the payload — queue transports rely on
+  queue composites (no HMAC signature on the payload: queue transports rely on
   AWS IAM for authentication). Transparent gzip via magic-byte detection.
 - New instance methods on `StreamSDKClient`: `verifySignature(body, signature)`
-  and `verifyAndParseWebhook(body, signature)` — drop the api_secret parameter
+  and `verifyAndParseWebhook(body, signature)` that drop the api_secret parameter
   in favor of the client's stored secret. Dual API: static `Webhook.*` methods
   remain available.
 - New instance methods on `StreamSDKClient`: `parseSqs(String)`, `parseSns(String)`
   (no signature; AWS IAM).
-- New exception class: `Webhook.InvalidWebhookException` (unified — covers both
+- New exception class: `Webhook.InvalidWebhookException` (unified, covering both
   signature mismatch and malformed payloads).
 - Conformance fixture suite under `src/test/resources/fixtures/webhooks/`.
 - Explicit HTTP connection pool configuration ([CHA-2956](https://linear.app/stream/issue/CHA-2956/connection-pooling)). New `StreamClientOptions` POJO with fluent setters:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,11 @@ All notable changes to this project will be documented in this file. See [standa
   signature mismatch and malformed payloads).
 - Conformance fixture suite under `src/test/resources/fixtures/webhooks/`.
 - Explicit HTTP connection pool configuration ([CHA-2956](https://linear.app/stream/issue/CHA-2956/connection-pooling)). New `StreamClientOptions` POJO with fluent setters:
-    * `setMaxConnsPerHost(int)` — default `5`
-    * `setIdleTimeout(Duration)` — default `55s`
-    * `setConnectTimeout(Duration)` — default `10s`
-    * `setRequestTimeout(Duration)` — default `30s` (was `10s`; see Behavior changes)
-    * `setHttpClient(OkHttpClient)` — escape hatch; bypasses the four knobs above
+    * `setMaxConnsPerHost(int)` - default `5`
+    * `setIdleTimeout(Duration)` - default `55s`
+    * `setConnectTimeout(Duration)` - default `10s`
+    * `setRequestTimeout(Duration)` - default `30s` (was `10s`; see Behavior changes)
+    * `setHttpClient(OkHttpClient)` - escape hatch; bypasses the four knobs above
   Pass via the new constructor: `new StreamSDKClient(apiKey, secret, options)`.
 - Per-call `RequestTimeout` override on `StreamRequest`: `request.callTimeout(Duration.ofSeconds(5)).execute()`.
 - INFO log on client construction lists the effective pool config. Uses `java.util.logging.Logger` (no new dependency).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,12 +20,35 @@ All notable changes to this project will be documented in this file. See [standa
 - New exception class: `Webhook.InvalidWebhookException` (unified — covers both
   signature mismatch and malformed payloads).
 - Conformance fixture suite under `src/test/resources/fixtures/webhooks/`.
+- Explicit HTTP connection pool configuration ([CHA-2956](https://linear.app/stream/issue/CHA-2956/connection-pooling)).
+  New `StreamClientOptions` POJO with fluent setters:
+    * `setMaxConnsPerHost(int)` — default `5`
+    * `setIdleTimeout(Duration)` — default `55s`
+    * `setConnectTimeout(Duration)` — default `10s`
+    * `setRequestTimeout(Duration)` — default `30s` (was `10s`; see Behavior changes)
+    * `setHttpClient(OkHttpClient)` — escape hatch; bypasses the four knobs above
+  Pass via the new constructor: `new StreamSDKClient(apiKey, secret, options)`.
+- Per-call `RequestTimeout` override on `StreamRequest`:
+  `request.callTimeout(Duration.ofSeconds(5)).execute()`. Spec §5.2.
+- INFO log on client construction lists the effective pool config (spec §8).
+  Uses `java.util.logging.Logger` (no new dependency).
 
 ### Changed
 
-- No breaking changes. All existing webhook helpers preserved.
+- **Default per-call `RequestTimeout` is now `30s` (was `10s`).** Aligns with CHA-2956
+  cross-SDK contract. The previous `10s` came from the hardcoded `timeout = 10000` ms
+  in `StreamHTTPClient`. To keep the old ceiling, pass
+  `new StreamClientOptions().setRequestTimeout(Duration.ofSeconds(10))`.
+- Default idle-connection lifetime now `55s` (was `59s` via the
+  `STREAM_API_CONNECTION_MAX_AGE` env var path). 55s sits 5s below the typical 60s
+  LB idle timeout for safer eviction. `MaxConnsPerHost` default is unchanged at `5`.
+- No other breaking changes. Existing `StreamSDKClient(apiKey, secret)`,
+  `StreamSDKClient(apiKey, secret, OkHttpClient)`, and `StreamSDKClient(Properties)`
+  constructors are preserved.
 
-[Spec](https://www.notion.so/stream-wiki/Server-Side-SDK-Webhook-Handling-Spec-34b6a5d7f9f681e78003c443f227493c)
+[Connection Pooling Spec](https://www.notion.so/stream-wiki/Server-Side-SDK-Connection-Pooling-Spec-3496a5d7f9f680749b8be9ee238ae108)
+
+[Webhook Spec](https://www.notion.so/stream-wiki/Server-Side-SDK-Webhook-Handling-Spec-34b6a5d7f9f681e78003c443f227493c)
 
 ## [7.2.0](https://github.com/GetStream/stream-sdk-java/compare/7.1.0...7.2.0) (2026-04-30)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,11 @@ All notable changes to this project will be documented in this file. See [standa
   signature mismatch and malformed payloads).
 - Conformance fixture suite under `src/test/resources/fixtures/webhooks/`.
 - Explicit HTTP connection pool configuration ([CHA-2956](https://linear.app/stream/issue/CHA-2956/connection-pooling)). New `StreamClientOptions` POJO with fluent setters:
-    * `setMaxConnsPerHost(int)` - default `5`
-    * `setIdleTimeout(Duration)` - default `55s`
-    * `setConnectTimeout(Duration)` - default `10s`
-    * `setRequestTimeout(Duration)` - default `30s` (was `10s`; see Behavior changes)
-    * `setHttpClient(OkHttpClient)` - escape hatch; bypasses the four knobs above
+    * `setMaxConnsPerHost(int)`: default `5`
+    * `setIdleTimeout(Duration)`: default `55s`
+    * `setConnectTimeout(Duration)`: default `10s`
+    * `setRequestTimeout(Duration)`: default `30s` (was `10s`; see Behavior changes)
+    * `setHttpClient(OkHttpClient)`: escape hatch; bypasses the four knobs above
   Pass via the new constructor: `new StreamSDKClient(apiKey, secret, options)`.
 - Per-call `RequestTimeout` override on `StreamRequest`: `request.callTimeout(Duration.ofSeconds(5)).execute()`.
 - INFO log on client construction lists the effective pool config. Uses `java.util.logging.Logger` (no new dependency).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,8 @@ All notable changes to this project will be documented in this file. See [standa
     * `setHttpClient(OkHttpClient)` — escape hatch; bypasses the four knobs above
   Pass via the new constructor: `new StreamSDKClient(apiKey, secret, options)`.
 - Per-call `RequestTimeout` override on `StreamRequest`:
-  `request.callTimeout(Duration.ofSeconds(5)).execute()`. Spec §5.2.
-- INFO log on client construction lists the effective pool config (spec §8).
+  `request.callTimeout(Duration.ofSeconds(5)).execute()`.
+- INFO log on client construction lists the effective pool config.
   Uses `java.util.logging.Logger` (no new dependency).
 
 ### Changed
@@ -45,10 +45,6 @@ All notable changes to this project will be documented in this file. See [standa
 - No other breaking changes. Existing `StreamSDKClient(apiKey, secret)`,
   `StreamSDKClient(apiKey, secret, OkHttpClient)`, and `StreamSDKClient(Properties)`
   constructors are preserved.
-
-[Connection Pooling Spec](https://www.notion.so/stream-wiki/Server-Side-SDK-Connection-Pooling-Spec-3496a5d7f9f680749b8be9ee238ae108)
-
-[Webhook Spec](https://www.notion.so/stream-wiki/Server-Side-SDK-Webhook-Handling-Spec-34b6a5d7f9f681e78003c443f227493c)
 
 ## [7.2.0](https://github.com/GetStream/stream-sdk-java/compare/7.1.0...7.2.0) (2026-04-30)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,31 +20,21 @@ All notable changes to this project will be documented in this file. See [standa
 - New exception class: `Webhook.InvalidWebhookException` (unified — covers both
   signature mismatch and malformed payloads).
 - Conformance fixture suite under `src/test/resources/fixtures/webhooks/`.
-- Explicit HTTP connection pool configuration ([CHA-2956](https://linear.app/stream/issue/CHA-2956/connection-pooling)).
-  New `StreamClientOptions` POJO with fluent setters:
+- Explicit HTTP connection pool configuration ([CHA-2956](https://linear.app/stream/issue/CHA-2956/connection-pooling)). New `StreamClientOptions` POJO with fluent setters:
     * `setMaxConnsPerHost(int)` — default `5`
     * `setIdleTimeout(Duration)` — default `55s`
     * `setConnectTimeout(Duration)` — default `10s`
     * `setRequestTimeout(Duration)` — default `30s` (was `10s`; see Behavior changes)
     * `setHttpClient(OkHttpClient)` — escape hatch; bypasses the four knobs above
   Pass via the new constructor: `new StreamSDKClient(apiKey, secret, options)`.
-- Per-call `RequestTimeout` override on `StreamRequest`:
-  `request.callTimeout(Duration.ofSeconds(5)).execute()`.
-- INFO log on client construction lists the effective pool config.
-  Uses `java.util.logging.Logger` (no new dependency).
+- Per-call `RequestTimeout` override on `StreamRequest`: `request.callTimeout(Duration.ofSeconds(5)).execute()`.
+- INFO log on client construction lists the effective pool config. Uses `java.util.logging.Logger` (no new dependency).
 
 ### Changed
 
-- **Default per-call `RequestTimeout` is now `30s` (was `10s`).** Aligns with CHA-2956
-  cross-SDK contract. The previous `10s` came from the hardcoded `timeout = 10000` ms
-  in `StreamHTTPClient`. To keep the old ceiling, pass
-  `new StreamClientOptions().setRequestTimeout(Duration.ofSeconds(10))`.
-- Default idle-connection lifetime now `55s` (was `59s` via the
-  `STREAM_API_CONNECTION_MAX_AGE` env var path). 55s sits 5s below the typical 60s
-  LB idle timeout for safer eviction. `MaxConnsPerHost` default is unchanged at `5`.
-- No other breaking changes. Existing `StreamSDKClient(apiKey, secret)`,
-  `StreamSDKClient(apiKey, secret, OkHttpClient)`, and `StreamSDKClient(Properties)`
-  constructors are preserved.
+- **Default per-call `RequestTimeout` is now `30s` (was `10s`).** Aligns with CHA-2956 cross-SDK contract. The previous `10s` came from the hardcoded `timeout = 10000` ms in `StreamHTTPClient`. To keep the old ceiling, pass `new StreamClientOptions().setRequestTimeout(Duration.ofSeconds(10))`.
+- Default idle-connection lifetime now `55s` (was `59s` via the `STREAM_API_CONNECTION_MAX_AGE` env var path). 55s sits 5s below the typical 60s LB idle timeout for safer eviction. `MaxConnsPerHost` default is unchanged at `5`.
+- No other breaking changes. Existing `StreamSDKClient(apiKey, secret)`, `StreamSDKClient(apiKey, secret, OkHttpClient)`, and `StreamSDKClient(Properties)` constructors are preserved.
 
 ## [7.2.0](https://github.com/GetStream/stream-sdk-java/compare/7.1.0...7.2.0) (2026-04-30)
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=7.2.0
+version=7.3.0

--- a/src/main/java/io/getstream/Webhook.java
+++ b/src/main/java/io/getstream/Webhook.java
@@ -191,7 +191,7 @@ public class Webhook {
   private static final ObjectMapper objectMapper =
       new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
-  // gzipMagic is the two-byte gzip magic prefix (RFC 1952).
+  // gzipMagic is the two-byte gzip magic prefix (RFC 1952 §2.3.1).
   // JSON cannot start with these bytes, so this gives unambiguous detection
   // for Stream's always-JSON payloads.
   private static final byte[] GZIP_MAGIC = {0x1F, (byte) 0x8B};
@@ -944,8 +944,8 @@ public class Webhook {
    * not valid base64, so the base64 decode fails and we fall through to raw bytes, then {@link
    * #gunzipPayload(byte[])}'s magic-byte detection decides whether to decompress.
    *
-   * <p>{@link #parseSqs(String)} sits on top of this and works transparently for both wire formats:
-   * no caller code change, no flag, no header.
+   * <p>{@link #parseSqs(String)} sits on top of this and works transparently for both wire formats
+   * — no caller code change, no flag, no header.
    *
    * @throws InvalidWebhookError if gzip decompression fails (only when input has gzip magic prefix)
    */
@@ -958,7 +958,7 @@ public class Webhook {
     try {
       decoded = Base64.getDecoder().decode(messageBody);
     } catch (IllegalArgumentException e) {
-      // Not base64, so treat input as raw bytes (uncompressed wire format).
+      // Not base64 — treat input as raw bytes (uncompressed wire format).
       decoded = messageBody.getBytes(StandardCharsets.UTF_8);
     }
     return gunzipPayload(decoded);
@@ -970,8 +970,9 @@ public class Webhook {
    * through.
    *
    * <p>Heuristic: try to JSON-parse the input. If it yields an object with a string {@code Message}
-   * field, that's the envelope shape; return the Message. Otherwise the input is presumed to BE the
-   * pre-extracted Message (base64-encoded bytes are not valid JSON, so this falls through cleanly).
+   * field, that's the envelope shape — return the Message. Otherwise the input is presumed to BE
+   * the pre-extracted Message (base64-encoded bytes are not valid JSON, so this falls through
+   * cleanly).
    */
   private static String unwrapSnsNotificationBody(String body) {
     try {
@@ -981,7 +982,7 @@ public class Webhook {
         return msg.asText();
       }
     } catch (IOException e) {
-      // not JSON, so fall through to treating body as a bare Message string
+      // not JSON — fall through to treating body as a bare Message string
     }
     return body;
   }

--- a/src/main/java/io/getstream/Webhook.java
+++ b/src/main/java/io/getstream/Webhook.java
@@ -191,7 +191,7 @@ public class Webhook {
   private static final ObjectMapper objectMapper =
       new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
-  // gzipMagic is the two-byte gzip magic prefix (RFC 1952 §2.3.1).
+  // gzipMagic is the two-byte gzip magic prefix (RFC 1952).
   // JSON cannot start with these bytes, so this gives unambiguous detection
   // for Stream's always-JSON payloads.
   private static final byte[] GZIP_MAGIC = {0x1F, (byte) 0x8B};

--- a/src/main/java/io/getstream/Webhook.java
+++ b/src/main/java/io/getstream/Webhook.java
@@ -944,8 +944,8 @@ public class Webhook {
    * not valid base64, so the base64 decode fails and we fall through to raw bytes, then {@link
    * #gunzipPayload(byte[])}'s magic-byte detection decides whether to decompress.
    *
-   * <p>{@link #parseSqs(String)} sits on top of this and works transparently for both wire formats
-   * — no caller code change, no flag, no header.
+   * <p>{@link #parseSqs(String)} sits on top of this and works transparently for both wire formats:
+   * no caller code change, no flag, no header.
    *
    * @throws InvalidWebhookError if gzip decompression fails (only when input has gzip magic prefix)
    */
@@ -958,7 +958,7 @@ public class Webhook {
     try {
       decoded = Base64.getDecoder().decode(messageBody);
     } catch (IllegalArgumentException e) {
-      // Not base64 — treat input as raw bytes (uncompressed wire format).
+      // Not base64, so treat input as raw bytes (uncompressed wire format).
       decoded = messageBody.getBytes(StandardCharsets.UTF_8);
     }
     return gunzipPayload(decoded);
@@ -970,9 +970,8 @@ public class Webhook {
    * through.
    *
    * <p>Heuristic: try to JSON-parse the input. If it yields an object with a string {@code Message}
-   * field, that's the envelope shape — return the Message. Otherwise the input is presumed to BE
-   * the pre-extracted Message (base64-encoded bytes are not valid JSON, so this falls through
-   * cleanly).
+   * field, that's the envelope shape; return the Message. Otherwise the input is presumed to BE the
+   * pre-extracted Message (base64-encoded bytes are not valid JSON, so this falls through cleanly).
    */
   private static String unwrapSnsNotificationBody(String body) {
     try {
@@ -982,7 +981,7 @@ public class Webhook {
         return msg.asText();
       }
     } catch (IOException e) {
-      // not JSON — fall through to treating body as a bare Message string
+      // not JSON, so fall through to treating body as a bare Message string
     }
     return body;
   }

--- a/src/main/java/io/getstream/services/framework/StreamClientOptions.java
+++ b/src/main/java/io/getstream/services/framework/StreamClientOptions.java
@@ -6,9 +6,9 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * Tunables for the SDK's HTTP transport / connection pool. Per CHA-2956 connection pooling spec.
- * Defaults: 5 conns/host, 55s idle, 10s connect, 30s request. HTTP keep-alive is always on. {@link
- * #setHttpClient(OkHttpClient)} is the §7 escape hatch — when set, the four knobs are ignored.
+ * Tunables for the SDK's HTTP transport / connection pool. Per CHA-2956. Defaults: 5 conns/host,
+ * 55s idle, 10s connect, 30s request. HTTP keep-alive is always on. {@link
+ * #setHttpClient(OkHttpClient)} is the escape hatch: when set, the four knobs are ignored.
  */
 public class StreamClientOptions {
   public static final int DEFAULT_MAX_CONNS_PER_HOST = 5;
@@ -49,7 +49,7 @@ public class StreamClientOptions {
     return this;
   }
 
-  /** Spec §7 escape hatch. When set, the four knobs above are ignored. */
+  /** Escape hatch: when set, the four knobs above are ignored. */
   public StreamClientOptions setHttpClient(@Nullable OkHttpClient client) {
     this.httpClient = client;
     return this;

--- a/src/main/java/io/getstream/services/framework/StreamClientOptions.java
+++ b/src/main/java/io/getstream/services/framework/StreamClientOptions.java
@@ -1,0 +1,85 @@
+package io.getstream.services.framework;
+
+import java.time.Duration;
+import okhttp3.OkHttpClient;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Tunables for the SDK's HTTP transport / connection pool. Per CHA-2956 connection pooling spec.
+ * Defaults: 5 conns/host, 55s idle, 10s connect, 30s request. HTTP keep-alive is always on. {@link
+ * #setHttpClient(OkHttpClient)} is the §7 escape hatch — when set, the four knobs are ignored.
+ */
+public class StreamClientOptions {
+  public static final int DEFAULT_MAX_CONNS_PER_HOST = 5;
+  public static final Duration DEFAULT_IDLE_TIMEOUT = Duration.ofSeconds(55);
+  public static final Duration DEFAULT_CONNECT_TIMEOUT = Duration.ofSeconds(10);
+  public static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofSeconds(30);
+
+  private int maxConnsPerHost = DEFAULT_MAX_CONNS_PER_HOST;
+  @NotNull private Duration idleTimeout = DEFAULT_IDLE_TIMEOUT;
+  @NotNull private Duration connectTimeout = DEFAULT_CONNECT_TIMEOUT;
+  @NotNull private Duration requestTimeout = DEFAULT_REQUEST_TIMEOUT;
+  @Nullable private OkHttpClient httpClient;
+
+  public StreamClientOptions setMaxConnsPerHost(int n) {
+    if (n <= 0) throw new IllegalArgumentException("maxConnsPerHost must be > 0, got " + n);
+    this.maxConnsPerHost = n;
+    return this;
+  }
+
+  public StreamClientOptions setIdleTimeout(@NotNull Duration d) {
+    if (d.isNegative() || d.isZero())
+      throw new IllegalArgumentException("idleTimeout must be positive, got " + d);
+    this.idleTimeout = d;
+    return this;
+  }
+
+  public StreamClientOptions setConnectTimeout(@NotNull Duration d) {
+    if (d.isNegative() || d.isZero())
+      throw new IllegalArgumentException("connectTimeout must be positive, got " + d);
+    this.connectTimeout = d;
+    return this;
+  }
+
+  public StreamClientOptions setRequestTimeout(@NotNull Duration d) {
+    if (d.isNegative() || d.isZero())
+      throw new IllegalArgumentException("requestTimeout must be positive, got " + d);
+    this.requestTimeout = d;
+    return this;
+  }
+
+  /** Spec §7 escape hatch. When set, the four knobs above are ignored. */
+  public StreamClientOptions setHttpClient(@Nullable OkHttpClient client) {
+    this.httpClient = client;
+    return this;
+  }
+
+  public int getMaxConnsPerHost() {
+    return maxConnsPerHost;
+  }
+
+  @NotNull
+  public Duration getIdleTimeout() {
+    return idleTimeout;
+  }
+
+  @NotNull
+  public Duration getConnectTimeout() {
+    return connectTimeout;
+  }
+
+  @NotNull
+  public Duration getRequestTimeout() {
+    return requestTimeout;
+  }
+
+  @Nullable
+  public OkHttpClient getHttpClient() {
+    return httpClient;
+  }
+
+  public boolean hasUserHttpClient() {
+    return httpClient != null;
+  }
+}

--- a/src/main/java/io/getstream/services/framework/StreamHTTPClient.java
+++ b/src/main/java/io/getstream/services/framework/StreamHTTPClient.java
@@ -17,6 +17,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 import javax.crypto.spec.SecretKeySpec;
 import okhttp3.ConnectionPool;
+import okhttp3.Dispatcher;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -159,17 +160,24 @@ public class StreamHTTPClient {
   }
 
   private OkHttpClient.Builder defaultHttpClientBuilder() {
-    long idleSeconds = options.getIdleTimeout().getSeconds();
+    long idleMillis = options.getIdleTimeout().toMillis();
+    // ConnectionPool's first arg is the idle-pool SIZE, not a per-host ceiling. The real per-host
+    // concurrency cap is Dispatcher.maxRequestsPerHost (OkHttp default 5), so wire maxConnsPerHost
+    // to both: the pool keeps that many idle connections warm, the dispatcher caps in-flight
+    // requests per host.
+    var dispatcher = new Dispatcher();
+    dispatcher.setMaxRequestsPerHost(options.getMaxConnsPerHost());
     return new OkHttpClient.Builder()
+        .dispatcher(dispatcher)
         .connectionPool(
-            new ConnectionPool(options.getMaxConnsPerHost(), idleSeconds, TimeUnit.SECONDS))
+            new ConnectionPool(options.getMaxConnsPerHost(), idleMillis, TimeUnit.MILLISECONDS))
         .connectTimeout(options.getConnectTimeout())
         .callTimeout(options.getRequestTimeout());
   }
 
   private void logEffectiveConfig() {
     if (options.hasUserHttpClient()) {
-      LOG.info("connection pool: user_http_client=true (5 knobs not applied)");
+      LOG.info("connection pool: user_http_client=true (4 knobs not applied)");
     } else {
       LOG.info(
           String.format(

--- a/src/main/java/io/getstream/services/framework/StreamHTTPClient.java
+++ b/src/main/java/io/getstream/services/framework/StreamHTTPClient.java
@@ -11,6 +11,7 @@ import io.jsonwebtoken.SignatureAlgorithm;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
+import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
@@ -205,6 +206,10 @@ public class StreamHTTPClient {
         env.getOrDefault("STREAM_API_TIMEOUT", System.getProperty(API_TIMEOUT_PROP_NAME));
     if (envTimeout != null) {
       timeout = Long.parseLong(envTimeout);
+      // Fold the legacy env/property override into the options object so the request-timeout knob
+      // actually honors it. Only done when the value was explicitly provided, so an unset env var
+      // leaves the StreamClientOptions default (30s) intact rather than the bare 10000ms field.
+      options.setRequestTimeout(Duration.ofMillis(timeout));
     }
 
     var envConnectionMaxAge =
@@ -212,6 +217,9 @@ public class StreamHTTPClient {
             "STREAM_API_CONNECTION_MAX_AGE", System.getProperty(API_CONNECTION_MAX_AGE_PROP_NAME));
     if (envConnectionMaxAge != null) {
       connectionMaxAgeSeconds = Long.parseLong(envConnectionMaxAge);
+      // Same as above: an explicit max-age maps onto the idle-timeout knob; absent, the options
+      // default (55s) wins over the bare 59s field.
+      options.setIdleTimeout(Duration.ofSeconds(connectionMaxAgeSeconds));
     }
 
     var envApiUrl = env.getOrDefault("STREAM_BASE_URL", System.getProperty(API_URL_PROP_NAME));

--- a/src/main/java/io/getstream/services/framework/StreamHTTPClient.java
+++ b/src/main/java/io/getstream/services/framework/StreamHTTPClient.java
@@ -13,6 +13,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
 import javax.crypto.spec.SecretKeySpec;
 import okhttp3.ConnectionPool;
 import okhttp3.HttpUrl;
@@ -21,6 +22,8 @@ import okhttp3.Request;
 import org.jetbrains.annotations.NotNull;
 
 public class StreamHTTPClient {
+  private static final Logger LOG = Logger.getLogger(StreamHTTPClient.class.getName());
+
   public static final String API_KEY_PROP_NAME = "io.getstream.apiKey";
   public static final String API_SECRET_PROP_NAME = "io.getstream.apiSecret";
   public static final String API_TIMEOUT_PROP_NAME = "io.getstream.timeout";
@@ -54,17 +57,36 @@ public class StreamHTTPClient {
   @NotNull private String logLevel = "NONE";
   @NotNull private String baseUrl = API_DEFAULT_URL;
   @NotNull private OkHttpClient client;
+  @NotNull private StreamClientOptions options = new StreamClientOptions();
 
   public StreamHTTPClient(@NotNull String apiKey, @NotNull String apiSecret) {
     setCredetials(apiKey, apiSecret);
+    logEffectiveConfig();
   }
 
   public StreamHTTPClient(
       @NotNull String apiKey, @NotNull String apiSecret, @NotNull OkHttpClient httpClient) {
+    this.options = new StreamClientOptions().setHttpClient(httpClient);
     this.apiKey = apiKey;
     this.apiSecret = apiSecret;
     var jwtToken = buildJWT(apiSecret);
     this.client = buildHTTPClient(jwtToken, httpClient.newBuilder());
+    logEffectiveConfig();
+  }
+
+  public StreamHTTPClient(
+      @NotNull String apiKey, @NotNull String apiSecret, @NotNull StreamClientOptions options) {
+    this.options = options;
+    if (options.hasUserHttpClient()) {
+      // Escape hatch: user owns the OkHttpClient. None of the pool/timeout knobs apply.
+      this.apiKey = apiKey;
+      this.apiSecret = apiSecret;
+      var jwtToken = buildJWT(apiSecret);
+      this.client = buildHTTPClient(jwtToken, options.getHttpClient().newBuilder());
+    } else {
+      setCredetials(apiKey, apiSecret);
+    }
+    logEffectiveConfig();
   }
 
   // default constructor using ENV or System properties
@@ -85,6 +107,7 @@ public class StreamHTTPClient {
     }
 
     setCredetials(apiKey, apiSecret);
+    logEffectiveConfig();
   }
 
   private static @NotNull String buildJWT(String apiSecret) {
@@ -135,9 +158,27 @@ public class StreamHTTPClient {
   }
 
   private OkHttpClient.Builder defaultHttpClientBuilder() {
+    long idleSeconds = options.getIdleTimeout().getSeconds();
     return new OkHttpClient.Builder()
-        .connectionPool(new ConnectionPool(5, connectionMaxAgeSeconds, TimeUnit.SECONDS))
-        .callTimeout(timeout, TimeUnit.MILLISECONDS);
+        .connectionPool(
+            new ConnectionPool(options.getMaxConnsPerHost(), idleSeconds, TimeUnit.SECONDS))
+        .connectTimeout(options.getConnectTimeout())
+        .callTimeout(options.getRequestTimeout());
+  }
+
+  private void logEffectiveConfig() {
+    if (options.hasUserHttpClient()) {
+      LOG.info("connection pool: user_http_client=true (5 knobs not applied)");
+    } else {
+      LOG.info(
+          String.format(
+              "connection pool: max_conns_per_host=%d idle_timeout=%s connect_timeout=%s"
+                  + " request_timeout=%s user_http_client=false",
+              options.getMaxConnsPerHost(),
+              options.getIdleTimeout(),
+              options.getConnectTimeout(),
+              options.getRequestTimeout()));
+    }
   }
 
   private void readPropertiesAndEnv(Properties properties) {

--- a/src/main/java/io/getstream/services/framework/StreamRequest.java
+++ b/src/main/java/io/getstream/services/framework/StreamRequest.java
@@ -12,9 +12,11 @@ import io.getstream.models.framework.RateLimit;
 import io.getstream.models.framework.StreamResponse;
 import java.io.File;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import okhttp3.*;
 import org.jetbrains.annotations.NotNull;
 
@@ -23,6 +25,7 @@ public class StreamRequest<T> {
   private final Request request;
   private final ObjectMapper objectMapper;
   private final TypeReference<T> typeReference;
+  private Duration callTimeoutOverride;
 
   public StreamRequest(
       OkHttpClient client,
@@ -223,8 +226,29 @@ public class StreamRequest<T> {
     return builder.build();
   }
 
+  /**
+   * Override the per-call timeout for this single request. The override takes precedence over the
+   * client-wide {@code RequestTimeout} configured via {@link
+   * io.getstream.services.framework.StreamClientOptions#setRequestTimeout}. Returns {@code this}
+   * for chaining.
+   *
+   * <p>Per CHA-2956 spec §5.2.
+   */
+  public StreamRequest<T> callTimeout(@NotNull Duration d) {
+    if (d.isNegative()) {
+      throw new IllegalArgumentException("callTimeout must be non-negative, got " + d);
+    }
+    this.callTimeoutOverride = d;
+    return this;
+  }
+
   public StreamResponse<T> execute() throws StreamException {
     okhttp3.Call call = client.newCall(request);
+    if (callTimeoutOverride != null) {
+      // OkHttp 4.x: Call.timeout() returns an okio.Timeout. Setting it overrides the
+      // client-wide callTimeout for this single dispatch.
+      call.timeout().timeout(callTimeoutOverride.toNanos(), TimeUnit.NANOSECONDS);
+    }
     Response response;
     try {
       response = call.execute();

--- a/src/main/java/io/getstream/services/framework/StreamRequest.java
+++ b/src/main/java/io/getstream/services/framework/StreamRequest.java
@@ -232,7 +232,7 @@ public class StreamRequest<T> {
    * io.getstream.services.framework.StreamClientOptions#setRequestTimeout}. Returns {@code this}
    * for chaining.
    *
-   * <p>Per CHA-2956 spec §5.2.
+   * <p>Per CHA-2956.
    */
   public StreamRequest<T> callTimeout(@NotNull Duration d) {
     if (d.isNegative()) {

--- a/src/main/java/io/getstream/services/framework/StreamRequest.java
+++ b/src/main/java/io/getstream/services/framework/StreamRequest.java
@@ -245,8 +245,8 @@ public class StreamRequest<T> {
   public StreamResponse<T> execute() throws StreamException {
     okhttp3.Call call = client.newCall(request);
     if (callTimeoutOverride != null) {
-      // OkHttp 4.x: Call.timeout() returns an okio.Timeout. Setting it overrides the
-      // client-wide callTimeout for this single dispatch.
+      // OkHttp 4.x: Call.timeout() returns an okio.Timeout. Setting it overrides the client-wide
+      // callTimeout for this single dispatch.
       call.timeout().timeout(callTimeoutOverride.toNanos(), TimeUnit.NANOSECONDS);
     }
     Response response;

--- a/src/main/java/io/getstream/services/framework/StreamSDKClient.java
+++ b/src/main/java/io/getstream/services/framework/StreamSDKClient.java
@@ -12,6 +12,11 @@ public class StreamSDKClient extends CommonImpl implements Common {
     this(new StreamHTTPClient(apiKey, apiSecret));
   }
 
+  public StreamSDKClient(
+      @NotNull String apiKey, @NotNull String apiSecret, @NotNull StreamClientOptions options) {
+    this(new StreamHTTPClient(apiKey, apiSecret, options));
+  }
+
   public StreamSDKClient() {
     this(new StreamHTTPClient());
   }

--- a/src/test/java/io/getstream/StreamHTTPClientTest.java
+++ b/src/test/java/io/getstream/StreamHTTPClientTest.java
@@ -256,4 +256,17 @@ public class StreamHTTPClientTest {
     assertEquals(7_000, built.connectTimeoutMillis());
     assertEquals(45_000, built.callTimeoutMillis());
   }
+
+  @Test
+  void testStreamSDKClientWithOptions() {
+    StreamClientOptions opts =
+        new StreamClientOptions()
+            .setMaxConnsPerHost(15)
+            .setRequestTimeout(Duration.ofSeconds(25));
+    StreamSDKClient sdk =
+        new StreamSDKClient("apiKey", "012345678901234567890123456789ab", opts);
+    OkHttpClient built = sdk.getHttpClient().getHttpClient();
+
+    assertEquals(25_000, built.callTimeoutMillis(), "RequestTimeout flows through SDK client");
+  }
 }

--- a/src/test/java/io/getstream/StreamHTTPClientTest.java
+++ b/src/test/java/io/getstream/StreamHTTPClientTest.java
@@ -265,11 +265,8 @@ public class StreamHTTPClientTest {
   @Test
   void testStreamSDKClientWithOptions() {
     StreamClientOptions opts =
-        new StreamClientOptions()
-            .setMaxConnsPerHost(15)
-            .setRequestTimeout(Duration.ofSeconds(25));
-    StreamSDKClient sdk =
-        new StreamSDKClient("apiKey", "012345678901234567890123456789ab", opts);
+        new StreamClientOptions().setMaxConnsPerHost(15).setRequestTimeout(Duration.ofSeconds(25));
+    StreamSDKClient sdk = new StreamSDKClient("apiKey", "012345678901234567890123456789ab", opts);
     OkHttpClient built = sdk.getHttpClient().getHttpClient();
 
     assertEquals(25_000, built.callTimeoutMillis(), "RequestTimeout flows through SDK client");
@@ -294,8 +291,7 @@ public class StreamHTTPClientTest {
             .setConnectTimeout(Duration.ofSeconds(99))
             .setRequestTimeout(Duration.ofSeconds(99));
 
-    StreamSDKClient sdk =
-        new StreamSDKClient("apiKey", "012345678901234567890123456789ab", opts);
+    StreamSDKClient sdk = new StreamSDKClient("apiKey", "012345678901234567890123456789ab", opts);
     OkHttpClient built = sdk.getHttpClient().getHttpClient();
 
     assertSame(customPool, built.connectionPool(), "user pool preserved");

--- a/src/test/java/io/getstream/StreamHTTPClientTest.java
+++ b/src/test/java/io/getstream/StreamHTTPClientTest.java
@@ -231,4 +231,29 @@ public class StreamHTTPClientTest {
     assertEquals(Duration.ofSeconds(5), opts.getConnectTimeout());
     assertEquals(Duration.ofSeconds(20), opts.getRequestTimeout());
   }
+
+  @Test
+  void testStreamHTTPClientUsesDefaultOptions() {
+    StreamHTTPClient http = new StreamHTTPClient("apiKey", "012345678901234567890123456789ab");
+    OkHttpClient built = http.getHttpClient();
+    assertNotNull(built.connectionPool());
+    assertEquals(10_000, built.connectTimeoutMillis(), "default ConnectTimeout = 10_000ms");
+    assertEquals(30_000, built.callTimeoutMillis(), "default RequestTimeout = 30_000ms");
+    // OkHttp 4.x does not expose ConnectionPool.maxIdleConnections() publicly; we cover the
+    // pass-through path indirectly via the options-driven test below + the escape-hatch test.
+  }
+
+  @Test
+  void testStreamHTTPClientAppliesCustomOptions() {
+    StreamClientOptions opts =
+        new StreamClientOptions()
+            .setMaxConnsPerHost(20)
+            .setIdleTimeout(Duration.ofSeconds(90))
+            .setConnectTimeout(Duration.ofSeconds(7))
+            .setRequestTimeout(Duration.ofSeconds(45));
+    OkHttpClient built =
+        new StreamHTTPClient("apiKey", "012345678901234567890123456789ab", opts).getHttpClient();
+    assertEquals(7_000, built.connectTimeoutMillis());
+    assertEquals(45_000, built.callTimeoutMillis());
+  }
 }

--- a/src/test/java/io/getstream/StreamHTTPClientTest.java
+++ b/src/test/java/io/getstream/StreamHTTPClientTest.java
@@ -353,4 +353,62 @@ public class StreamHTTPClientTest {
     assertTrue(got.contains("user_http_client=true"), got);
     assertTrue(got.contains("5 knobs not applied"), got);
   }
+
+  @Test
+  void testApiTimeoutEnvPropertyStillOverridesRequestTimeout() {
+    // Regression guard for CHA-2956: the legacy STREAM_API_TIMEOUT / io.getstream.timeout override
+    // must still take effect via the env/properties constructor path. The env var and the system
+    // property share one code path (getOrDefault falls through to the property), so driving it
+    // through the property exercises the same fold-into-options logic.
+    String prevTimeout = System.getProperty(StreamHTTPClient.API_TIMEOUT_PROP_NAME);
+    String prevKey = System.getProperty(StreamHTTPClient.API_KEY_PROP_NAME);
+    String prevSecret = System.getProperty(StreamHTTPClient.API_SECRET_PROP_NAME);
+    try {
+      System.setProperty(StreamHTTPClient.API_TIMEOUT_PROP_NAME, "12345");
+      System.setProperty(StreamHTTPClient.API_KEY_PROP_NAME, "apiKey");
+      System.setProperty(StreamHTTPClient.API_SECRET_PROP_NAME, "012345678901234567890123456789ab");
+
+      OkHttpClient built = new StreamHTTPClient(System.getProperties()).getHttpClient();
+      assertEquals(
+          12_345,
+          built.callTimeoutMillis(),
+          "STREAM_API_TIMEOUT / io.getstream.timeout must drive the request (call) timeout");
+    } finally {
+      restoreProperty(StreamHTTPClient.API_TIMEOUT_PROP_NAME, prevTimeout);
+      restoreProperty(StreamHTTPClient.API_KEY_PROP_NAME, prevKey);
+      restoreProperty(StreamHTTPClient.API_SECRET_PROP_NAME, prevSecret);
+    }
+  }
+
+  @Test
+  void testConnectionMaxAgeEnvPropertyStillOverridesIdleTimeout() {
+    // Regression guard for CHA-2956: STREAM_API_CONNECTION_MAX_AGE / io.getstream.connection.maxAge
+    // must still take effect. OkHttp's ConnectionPool does not expose idle-ms publicly, so we
+    // assert via the effective-config INFO log, which reads options.getIdleTimeout().
+    String prevMaxAge = System.getProperty(StreamHTTPClient.API_CONNECTION_MAX_AGE_PROP_NAME);
+    String prevKey = System.getProperty(StreamHTTPClient.API_KEY_PROP_NAME);
+    String prevSecret = System.getProperty(StreamHTTPClient.API_SECRET_PROP_NAME);
+    try {
+      System.setProperty(StreamHTTPClient.API_CONNECTION_MAX_AGE_PROP_NAME, "123");
+      System.setProperty(StreamHTTPClient.API_KEY_PROP_NAME, "apiKey");
+      System.setProperty(StreamHTTPClient.API_SECRET_PROP_NAME, "012345678901234567890123456789ab");
+
+      String got = captureLastPoolLog(() -> new StreamHTTPClient(System.getProperties()));
+      assertTrue(
+          got.contains("idle_timeout=PT2M3S"),
+          "STREAM_API_CONNECTION_MAX_AGE must drive the idle timeout (123s = PT2M3S), got: " + got);
+    } finally {
+      restoreProperty(StreamHTTPClient.API_CONNECTION_MAX_AGE_PROP_NAME, prevMaxAge);
+      restoreProperty(StreamHTTPClient.API_KEY_PROP_NAME, prevKey);
+      restoreProperty(StreamHTTPClient.API_SECRET_PROP_NAME, prevSecret);
+    }
+  }
+
+  private static void restoreProperty(String key, String prev) {
+    if (prev == null) {
+      System.clearProperty(key);
+    } else {
+      System.setProperty(key, prev);
+    }
+  }
 }

--- a/src/test/java/io/getstream/StreamHTTPClientTest.java
+++ b/src/test/java/io/getstream/StreamHTTPClientTest.java
@@ -12,10 +12,15 @@ import io.getstream.services.framework.StreamClientOptions;
 import io.getstream.services.framework.StreamHTTPClient;
 import io.getstream.services.framework.StreamSDKClient;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 import okhttp3.ConnectionPool;
 import okhttp3.OkHttpClient;
 import org.junit.jupiter.api.BeforeAll;
@@ -298,5 +303,58 @@ public class StreamHTTPClientTest {
     assertEquals(88_000, built.callTimeoutMillis(), "user callTimeout preserved");
     assertFalse(
         built.interceptors().isEmpty(), "SDK still adds its interceptors to user-supplied client");
+  }
+
+  private static class CapturingHandler extends Handler {
+    final List<String> messages = new ArrayList<>();
+
+    @Override
+    public void publish(LogRecord r) {
+      if (r.getLevel().intValue() >= Level.INFO.intValue()) messages.add(r.getMessage());
+    }
+
+    @Override
+    public void flush() {}
+
+    @Override
+    public void close() throws SecurityException {}
+  }
+
+  private String captureLastPoolLog(Runnable construct) {
+    Logger jul = Logger.getLogger("io.getstream.services.framework.StreamHTTPClient");
+    CapturingHandler h = new CapturingHandler();
+    jul.addHandler(h);
+    try {
+      construct.run();
+      return h.messages.stream()
+          .filter(m -> m.startsWith("connection pool:"))
+          .reduce((a, b) -> b)
+          .orElseThrow();
+    } finally {
+      jul.removeHandler(h);
+    }
+  }
+
+  @Test
+  void testInfoLogOnConstructionWithDefaults() {
+    String got =
+        captureLastPoolLog(
+            () -> new StreamHTTPClient("apiKey", "012345678901234567890123456789ab"));
+    assertTrue(got.contains("max_conns_per_host=5"), got);
+    assertTrue(got.contains("idle_timeout=PT55S"), got);
+    assertTrue(got.contains("connect_timeout=PT10S"), got);
+    assertTrue(got.contains("request_timeout=PT30S"), got);
+    assertTrue(got.contains("user_http_client=false"), got);
+  }
+
+  @Test
+  void testInfoLogOnConstructionWithUserHttpClient() {
+    StreamClientOptions opts =
+        new StreamClientOptions().setHttpClient(new OkHttpClient.Builder().build());
+    String got =
+        captureLastPoolLog(
+            () -> new StreamHTTPClient("apiKey", "012345678901234567890123456789ab", opts));
+    assertTrue(got.contains("user_http_client=true"), got);
+    assertTrue(got.contains("5 knobs not applied"), got);
   }
 }

--- a/src/test/java/io/getstream/StreamHTTPClientTest.java
+++ b/src/test/java/io/getstream/StreamHTTPClientTest.java
@@ -351,7 +351,27 @@ public class StreamHTTPClientTest {
         captureLastPoolLog(
             () -> new StreamHTTPClient("apiKey", "012345678901234567890123456789ab", opts));
     assertTrue(got.contains("user_http_client=true"), got);
-    assertTrue(got.contains("5 knobs not applied"), got);
+    assertTrue(got.contains("4 knobs not applied"), got);
+  }
+
+  @Test
+  void testStreamHTTPClientDispatcherCapsRequestsPerHost() {
+    StreamClientOptions opts = new StreamClientOptions().setMaxConnsPerHost(17);
+    OkHttpClient built =
+        new StreamHTTPClient("apiKey", "012345678901234567890123456789ab", opts).getHttpClient();
+    assertEquals(
+        17,
+        built.dispatcher().getMaxRequestsPerHost(),
+        "maxConnsPerHost must drive Dispatcher.maxRequestsPerHost (the real per-host cap)");
+  }
+
+  @Test
+  void testDispatcherDefaultPerHostCapUnchanged() {
+    // OkHttp's default maxRequestsPerHost is 5, equal to our default maxConnsPerHost, so the
+    // default per-host concurrency is unchanged (the BLOCKER fix is not a behavior break).
+    OkHttpClient built =
+        new StreamHTTPClient("apiKey", "012345678901234567890123456789ab").getHttpClient();
+    assertEquals(5, built.dispatcher().getMaxRequestsPerHost());
   }
 
   @Test

--- a/src/test/java/io/getstream/StreamHTTPClientTest.java
+++ b/src/test/java/io/getstream/StreamHTTPClientTest.java
@@ -8,8 +8,10 @@ import io.getstream.models.MessageResponse;
 import io.getstream.models.TrackActivityMetricsEvent;
 import io.getstream.models.TrackActivityMetricsRequest;
 import io.getstream.models.UpdateAppRequest;
+import io.getstream.services.framework.StreamClientOptions;
 import io.getstream.services.framework.StreamHTTPClient;
 import io.getstream.services.framework.StreamSDKClient;
+import java.time.Duration;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -204,5 +206,29 @@ public class StreamHTTPClientTest {
         String.format(
             "Expected timestamp %d (2024-01-06T12:00:00Z) but got %d (%s)",
             expectedDate.getTime(), message.getUpdatedAt().getTime(), message.getUpdatedAt()));
+  }
+
+  @Test
+  void testStreamClientOptionsDefaults() {
+    StreamClientOptions opts = new StreamClientOptions();
+    assertEquals(5, opts.getMaxConnsPerHost(), "default MaxConnsPerHost = 5");
+    assertEquals(Duration.ofSeconds(55), opts.getIdleTimeout(), "default IdleTimeout = 55s");
+    assertEquals(Duration.ofSeconds(10), opts.getConnectTimeout(), "default ConnectTimeout = 10s");
+    assertEquals(Duration.ofSeconds(30), opts.getRequestTimeout(), "default RequestTimeout = 30s");
+    assertNull(opts.getHttpClient(), "no user-supplied OkHttpClient by default");
+  }
+
+  @Test
+  void testStreamClientOptionsFluentSetters() {
+    StreamClientOptions opts =
+        new StreamClientOptions()
+            .setMaxConnsPerHost(10)
+            .setIdleTimeout(Duration.ofSeconds(120))
+            .setConnectTimeout(Duration.ofSeconds(5))
+            .setRequestTimeout(Duration.ofSeconds(20));
+    assertEquals(10, opts.getMaxConnsPerHost());
+    assertEquals(Duration.ofSeconds(120), opts.getIdleTimeout());
+    assertEquals(Duration.ofSeconds(5), opts.getConnectTimeout());
+    assertEquals(Duration.ofSeconds(20), opts.getRequestTimeout());
   }
 }

--- a/src/test/java/io/getstream/StreamHTTPClientTest.java
+++ b/src/test/java/io/getstream/StreamHTTPClientTest.java
@@ -269,4 +269,34 @@ public class StreamHTTPClientTest {
 
     assertEquals(25_000, built.callTimeoutMillis(), "RequestTimeout flows through SDK client");
   }
+
+  @Test
+  void testEscapeHatchViaOptionsBypassesKnobs() {
+    ConnectionPool customPool = new ConnectionPool(42, 200, TimeUnit.SECONDS);
+    OkHttpClient userClient =
+        new OkHttpClient.Builder()
+            .connectionPool(customPool)
+            .connectTimeout(77, TimeUnit.SECONDS)
+            .callTimeout(88, TimeUnit.SECONDS)
+            .build();
+
+    StreamClientOptions opts =
+        new StreamClientOptions()
+            .setHttpClient(userClient)
+            // All four below MUST be ignored when an OkHttpClient is supplied:
+            .setMaxConnsPerHost(99)
+            .setIdleTimeout(Duration.ofSeconds(99))
+            .setConnectTimeout(Duration.ofSeconds(99))
+            .setRequestTimeout(Duration.ofSeconds(99));
+
+    StreamSDKClient sdk =
+        new StreamSDKClient("apiKey", "012345678901234567890123456789ab", opts);
+    OkHttpClient built = sdk.getHttpClient().getHttpClient();
+
+    assertSame(customPool, built.connectionPool(), "user pool preserved");
+    assertEquals(77_000, built.connectTimeoutMillis(), "user connectTimeout preserved");
+    assertEquals(88_000, built.callTimeoutMillis(), "user callTimeout preserved");
+    assertFalse(
+        built.interceptors().isEmpty(), "SDK still adds its interceptors to user-supplied client");
+  }
 }

--- a/src/test/java/io/getstream/StreamRequestCallTimeoutTest.java
+++ b/src/test/java/io/getstream/StreamRequestCallTimeoutTest.java
@@ -1,0 +1,60 @@
+package io.getstream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.getstream.exceptions.StreamException;
+import io.getstream.services.framework.StreamClientOptions;
+import io.getstream.services.framework.StreamHTTPClient;
+import io.getstream.services.framework.StreamRequest;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class StreamRequestCallTimeoutTest {
+  private MockWebServer server;
+
+  @BeforeEach
+  void start() throws IOException {
+    server = new MockWebServer();
+    server.start();
+  }
+
+  @AfterEach
+  void stop() throws IOException {
+    server.shutdown();
+  }
+
+  @Test
+  void perCallTimeoutOverridesClientDefault() throws StreamException {
+    server.enqueue(new MockResponse().setBody("{}").setBodyDelay(2, TimeUnit.SECONDS));
+    StreamHTTPClient http =
+        new StreamHTTPClient(
+            "apiKey",
+            "012345678901234567890123456789ab",
+            new StreamClientOptions().setRequestTimeout(Duration.ofSeconds(30)));
+
+    StreamRequest<Map<String, Object>> req =
+        new StreamRequest<>(
+            http.getHttpClient(),
+            http.getObjectMapper(),
+            server.url("/").toString(),
+            "GET",
+            "ping",
+            null,
+            null,
+            new TypeReference<Map<String, Object>>() {});
+
+    long start = System.nanoTime();
+    assertThrows(StreamException.class, () -> req.callTimeout(Duration.ofMillis(100)).execute());
+    long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+    assertTrue(
+        elapsedMs < 1_500, "per-call timeout pre-empts client default; took " + elapsedMs + "ms");
+  }
+}


### PR DESCRIPTION
## Summary

Implements explicit HTTP connection pooling for stream-sdk-java (CHA-2956).

- New `StreamClientOptions` POJO with fluent setters for the 5 canonical knobs: `setMaxConnsPerHost`, `setIdleTimeout`, `setConnectTimeout`, `setRequestTimeout`, `setHttpClient`.
- New `StreamSDKClient(apiKey, secret, StreamClientOptions)` constructor overload.
- Defaults: 5 / 55s / 10s / 30s.
- INFO log on construction via `java.util.logging.Logger`. No new dependency.
- Per-call `RequestTimeout` override: `request.callTimeout(Duration.ofSeconds(5)).execute()`.
- `setHttpClient(OkHttpClient)` is the escape hatch; bypasses all 4 knobs.
- Existing 3-arg `StreamSDKClient(apiKey, secret, OkHttpClient)` escape hatch preserved.

Version bump 7.2.0 to 7.3.0.

## Behavior change

Default per-call `RequestTimeout` moves from 10s to 30s. Aligns with the cross-SDK contract. Existing callers needing the old 10s ceiling should pass `new StreamClientOptions().setRequestTimeout(Duration.ofSeconds(10))`. CHANGELOG calls this out under "Changed."

## Test plan

- [x] `StreamClientOptions` defaults + fluent setter chaining
- [x] `StreamHTTPClient` uses options-derived `ConnectionPool` + `connectTimeout` + `callTimeout`
- [x] `StreamSDKClient(apiKey, secret, options)` constructor flows options through
- [x] `setHttpClient(OkHttpClient)` escape hatch via options: 4 knobs bypassed, user pool/timeouts preserved
- [x] Legacy `StreamSDKClient(apiKey, secret, OkHttpClient)` escape hatch still works
- [x] Per-call `request.callTimeout(Duration)` pre-empts client-wide `callTimeout` (MockWebServer)
- [x] INFO log on construction with defaults (asserts each knob + `user_http_client=false`)
- [x] INFO log on construction with `setHttpClient` (asserts `user_http_client=true`)
- [x] `./gradlew spotlessApply` clean
- [x] `./gradlew test --no-daemon --tests 'io.getstream.StreamHTTPClientTest' --tests 'io.getstream.StreamRequestCallTimeoutTest'` 17/17 PASS
- [x] `./gradlew build --no-daemon -x test` BUILD SUCCESSFUL

### Note on full integration suite

`./gradlew test --no-daemon` (full suite) fails on `ChatChannelIntegrationTest.testHardDeleteChannels` with `Task ... did not complete after 30 attempts`. This is a pre-existing live-server timing flake; the same test fails identically on `origin/main` in the full-suite run. The 30s polling window in `waitForTask` is insufficient when the live backend's async hard-delete task processor is under load. Unrelated to this change. Verified by running the full suite on `origin/main` immediately before this PR.

## Refs

- Linear: [CHA-2956](https://linear.app/stream/issue/CHA-2956/connection-pooling)