### PR TITLE
feat: [CHA-2958] typed error hierarchy + waitForTask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### Added
 
+- Typed error hierarchy for the Stream API per [CHA-2958](https://linear.app/stream/issue/CHA-2958). New checked subclasses of the existing `StreamException`:
+    * `StreamApiException` — HTTP 4xx/5xx with the `APIError` envelope parsed. Getters: `getStatusCode`, `getCode`, `getMessage`, `getExceptionFields`, `isUnrecoverable`, `getRawResponseBody`, `getMoreInfo`, `getDetails`. The `unrecoverable` and `details` fields were previously dropped on the floor.
+    * `StreamRateLimitException` — HTTP 429. Subclass of `StreamApiException` with `Duration getRetryAfter()` populated from `Retry-After` (RFC 7231 §7.1.3 integer seconds + HTTP-date). `null` when header absent or unparseable.
+    * `StreamTransportException` — connection reset, timeout, DNS, TLS, etc. Carries `getErrorType()` matching the logging spec enum (`connection_reset` / `timeout` / `dns_failure` / `tls_handshake_failed` / `unknown`). Cause chain preserved.
+    * `StreamTaskException` — async task observed with `status: "failed"`. Carries `getTaskId`, `getErrorType`, `getDescription`, `getStackTraceText`, `getVersion`. (`getStackTraceText` rather than `getStackTrace` to avoid colliding with `Throwable.getStackTrace()`.)
+- `StreamSDKClient.waitForTask(taskId)` — main-source helper that polls the task endpoint to a terminal state. Returns `GetTaskResponse` on `completed`, throws `StreamTaskException` on `failed`, throws `StreamTransportException(errorType=timeout)` if the wait elapses (defaults: 1s poll, 60s timeout; overloaded with explicit `Duration`s). Replaces the test-only `ChatTestBase.waitForTask` (removed).
 - Webhook handling spec helpers (CHA-2961): `UnknownEvent` class for forward-compat;
   `gunzipPayload`, `decodeSqsPayload`, `decodeSnsPayload` primitives;
   `verifyAndParseWebhook` HTTP composite; `parseSqs` / `parseSns`
@@ -32,6 +38,9 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### Changed
 
+- Exceptions remain **checked** (CHA-2958 §9.3). All new subclasses extend the existing checked `StreamException`, so `throws StreamException` declarations continue to compile and `catch (StreamException)` continues to handle every SDK error.
+- `StreamRequest` now throws `StreamApiException` (or `StreamRateLimitException` for 429) for HTTP-response errors, and `StreamTransportException` for IO failures. The static type on declarations is still `StreamException` — these are subclasses. The static `StreamException.build(Throwable)` factory continues to wrap into a base `StreamException` (the request path classifies transport failures directly so this factory is no longer auto-routed). `StreamException.getResponseData()` is still populated on API exceptions for back-compat.
+- The `APIError` envelope parser (formerly `StreamException.ResponseData`) gained the previously-dropped `details` and `unrecoverable` fields.
 - **Default per-call `RequestTimeout` is now `30s` (was `10s`).** Aligns with CHA-2956 cross-SDK contract. The previous `10s` came from the hardcoded `timeout = 10000` ms in `StreamHTTPClient`. To keep the old ceiling, pass `new StreamClientOptions().setRequestTimeout(Duration.ofSeconds(10))`.
 - Default idle-connection lifetime now `55s` (was `59s` via the `STREAM_API_CONNECTION_MAX_AGE` env var path). 55s sits 5s below the typical 60s LB idle timeout for safer eviction. `MaxConnsPerHost` default is unchanged at `5`.
 - No other breaking changes. Existing `StreamSDKClient(apiKey, secret)`, `StreamSDKClient(apiKey, secret, OkHttpClient)`, and `StreamSDKClient(Properties)` constructors are preserved.

--- a/src/main/java/io/getstream/exceptions/RetryAfterParser.java
+++ b/src/main/java/io/getstream/exceptions/RetryAfterParser.java
@@ -12,7 +12,7 @@ import org.jetbrains.annotations.Nullable;
  * <p>Accepts either non-negative integer seconds (e.g. {@code 30}) or an HTTP-date (IMF-fixdate,
  * e.g. {@code Fri, 31 Dec 2026 23:59:59 GMT}). HTTP-date values are converted to a delta from
  * {@code now()}, clamped to {@code >= 0}. Returns {@code null} when the header is absent or
- * unparseable — graceful per CHA-2958 §7.
+ * unparseable.
  */
 final class RetryAfterParser {
   private RetryAfterParser() {}

--- a/src/main/java/io/getstream/exceptions/RetryAfterParser.java
+++ b/src/main/java/io/getstream/exceptions/RetryAfterParser.java
@@ -1,0 +1,48 @@
+package io.getstream.exceptions;
+
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Parses the HTTP {@code Retry-After} header per RFC 7231 §7.1.3.
+ *
+ * <p>Accepts either non-negative integer seconds (e.g. {@code 30}) or an HTTP-date (IMF-fixdate,
+ * e.g. {@code Fri, 31 Dec 2026 23:59:59 GMT}). HTTP-date values are converted to a delta from
+ * {@code now()}, clamped to {@code >= 0}. Returns {@code null} when the header is absent or
+ * unparseable — graceful per CHA-2958 §7.
+ */
+final class RetryAfterParser {
+  private RetryAfterParser() {}
+
+  @Nullable
+  static Duration parse(@Nullable String header) {
+    if (header == null) {
+      return null;
+    }
+    String trimmed = header.trim();
+    if (trimmed.isEmpty()) {
+      return null;
+    }
+    // Integer seconds path.
+    try {
+      long seconds = Long.parseLong(trimmed);
+      if (seconds < 0) {
+        return Duration.ZERO;
+      }
+      return Duration.ofSeconds(seconds);
+    } catch (NumberFormatException ignored) {
+      // Fall through to HTTP-date parsing.
+    }
+    // HTTP-date (IMF-fixdate). RFC 7231 §7.1.1.1 says HTTP/1.1 servers MUST generate this form.
+    try {
+      ZonedDateTime when = ZonedDateTime.parse(trimmed, DateTimeFormatter.RFC_1123_DATE_TIME);
+      Duration delta = Duration.between(ZonedDateTime.now(when.getZone()), when);
+      return delta.isNegative() ? Duration.ZERO : delta;
+    } catch (DateTimeParseException ignored) {
+      return null;
+    }
+  }
+}

--- a/src/main/java/io/getstream/exceptions/StreamApiException.java
+++ b/src/main/java/io/getstream/exceptions/StreamApiException.java
@@ -1,0 +1,95 @@
+package io.getstream.exceptions;
+
+import java.util.Collections;
+import java.util.Map;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Thrown when the Stream API returns a 4xx/5xx response. Carries the parsed {@code APIError}
+ * envelope per CHA-2958 §5.1.
+ *
+ * <p>Checked subclass of {@link StreamException}: existing {@code throws StreamException}
+ * declarations continue to compile.
+ */
+public class StreamApiException extends StreamException {
+  private static final long serialVersionUID = 1L;
+
+  private final int statusCode;
+  private final int code;
+  private final Map<String, String> exceptionFields;
+  private final boolean unrecoverable;
+  private final String rawResponseBody;
+  @Nullable private final String moreInfo;
+  @Nullable private final Object details;
+
+  public StreamApiException(
+      String message,
+      int statusCode,
+      int code,
+      @Nullable Map<String, String> exceptionFields,
+      boolean unrecoverable,
+      String rawResponseBody,
+      @Nullable String moreInfo,
+      @Nullable Object details,
+      @Nullable Throwable cause) {
+    super(message, cause, buildResponseData(statusCode, code, message, exceptionFields,
+        unrecoverable, rawResponseBody, moreInfo, details));
+    this.statusCode = statusCode;
+    this.code = code;
+    this.exceptionFields = exceptionFields != null ? exceptionFields : Collections.emptyMap();
+    this.unrecoverable = unrecoverable;
+    this.rawResponseBody = rawResponseBody != null ? rawResponseBody : "";
+    this.moreInfo = moreInfo;
+    this.details = details;
+  }
+
+  private static ResponseData buildResponseData(
+      int statusCode,
+      int code,
+      String message,
+      @Nullable Map<String, String> exceptionFields,
+      boolean unrecoverable,
+      String rawResponseBody,
+      @Nullable String moreInfo,
+      @Nullable Object details) {
+    ResponseData rd = new ResponseData();
+    rd.setStatusCode(statusCode);
+    rd.setCode(code);
+    rd.setMessage(message);
+    rd.setExceptionFields(exceptionFields);
+    rd.setUnrecoverable(unrecoverable);
+    rd.setMoreInfo(moreInfo);
+    rd.setDetails(details);
+    return rd;
+  }
+
+  public int getStatusCode() {
+    return statusCode;
+  }
+
+  public int getCode() {
+    return code;
+  }
+
+  public Map<String, String> getExceptionFields() {
+    return exceptionFields;
+  }
+
+  public boolean isUnrecoverable() {
+    return unrecoverable;
+  }
+
+  public String getRawResponseBody() {
+    return rawResponseBody;
+  }
+
+  @Nullable
+  public String getMoreInfo() {
+    return moreInfo;
+  }
+
+  @Nullable
+  public Object getDetails() {
+    return details;
+  }
+}

--- a/src/main/java/io/getstream/exceptions/StreamApiException.java
+++ b/src/main/java/io/getstream/exceptions/StreamApiException.java
@@ -6,7 +6,7 @@ import org.jetbrains.annotations.Nullable;
 
 /**
  * Thrown when the Stream API returns a 4xx/5xx response. Carries the parsed {@code APIError}
- * envelope per CHA-2958 §5.1.
+ * envelope.
  *
  * <p>Checked subclass of {@link StreamException}: existing {@code throws StreamException}
  * declarations continue to compile.

--- a/src/main/java/io/getstream/exceptions/StreamApiException.java
+++ b/src/main/java/io/getstream/exceptions/StreamApiException.java
@@ -32,8 +32,18 @@ public class StreamApiException extends StreamException {
       @Nullable String moreInfo,
       @Nullable Object details,
       @Nullable Throwable cause) {
-    super(message, cause, buildResponseData(statusCode, code, message, exceptionFields,
-        unrecoverable, rawResponseBody, moreInfo, details));
+    super(
+        message,
+        cause,
+        buildResponseData(
+            statusCode,
+            code,
+            message,
+            exceptionFields,
+            unrecoverable,
+            rawResponseBody,
+            moreInfo,
+            details));
     this.statusCode = statusCode;
     this.code = code;
     this.exceptionFields = exceptionFields != null ? exceptionFields : Collections.emptyMap();

--- a/src/main/java/io/getstream/exceptions/StreamException.java
+++ b/src/main/java/io/getstream/exceptions/StreamException.java
@@ -29,8 +29,7 @@ public class StreamException extends Exception {
     super(t);
   }
 
-  // Allows subclasses (StreamApiException) to set both the cause and the back-compat responseData
-  // mirror in a single super() call. Package-private: only the exceptions package builds these.
+  // Package-private: subclasses construct via this with a parsed ResponseData mirror.
   StreamException(String message, Throwable cause, ResponseData responseData) {
     super(message, cause);
     this.responseData = responseData;
@@ -49,9 +48,8 @@ public class StreamException extends Exception {
   /**
    * Builds a typed API exception from the Stream API error body.
    *
-   * <p>Per CHA-2958 §6.2: parseable {@code APIError} envelope → {@link StreamApiException};
-   * unparseable body but HTTP layer succeeded → {@code StreamApiException} with {@code code=0} and
-   * the raw body preserved (§6.3).
+   * <p>Parseable {@code APIError} envelope → {@link StreamApiException}; unparseable body but HTTP
+   * layer succeeded → {@code StreamApiException} with {@code code=0} and the raw body preserved.
    *
    * <p>This overload does not see the status code; callers that have a {@link Response} should
    * prefer {@link #build(Response)} so 429 is routed to {@link StreamRateLimitException} and {@code
@@ -76,9 +74,9 @@ public class StreamException extends Exception {
   }
 
   /**
-   * Builds a typed API exception from an HTTP response. Per CHA-2958 §6.2: 429 → {@link
-   * StreamRateLimitException} with {@code Retry-After} parsed per RFC 7231 §7.1.3 (integer seconds
-   * or HTTP-date). Other 4xx/5xx → {@link StreamApiException}.
+   * Builds a typed API exception from an HTTP response. 429 → {@link StreamRateLimitException} with
+   * {@code Retry-After} parsed per RFC 7231 §7.1.3 (integer seconds or HTTP-date). Other 4xx/5xx →
+   * {@link StreamApiException}.
    */
   public static StreamException build(Response httpResponse) {
     int status = httpResponse.code();
@@ -157,8 +155,6 @@ public class StreamException extends Exception {
     return new StreamException(t);
   }
 
-  // statusCode comes from the HTTP layer (§5.1: "Source: HTTP status"). The envelope's
-  // StatusCode is only used as a fallback by build(ResponseBody), which has no live response.
   private static StreamApiException apiExceptionFromResponseData(
       ResponseData rd, String rawBody, int statusCode, Throwable cause) {
     return new StreamApiException(

--- a/src/main/java/io/getstream/exceptions/StreamException.java
+++ b/src/main/java/io/getstream/exceptions/StreamException.java
@@ -50,12 +50,12 @@ public class StreamException extends Exception {
    * Builds a typed API exception from the Stream API error body.
    *
    * <p>Per CHA-2958 §6.2: parseable {@code APIError} envelope → {@link StreamApiException};
-   * unparseable body but HTTP layer succeeded → {@code StreamApiException} with {@code code=0}
-   * and the raw body preserved (§6.3).
+   * unparseable body but HTTP layer succeeded → {@code StreamApiException} with {@code code=0} and
+   * the raw body preserved (§6.3).
    *
    * <p>This overload does not see the status code; callers that have a {@link Response} should
-   * prefer {@link #build(Response)} so 429 is routed to {@link StreamRateLimitException} and
-   * {@code statusCode} is preserved.
+   * prefer {@link #build(Response)} so 429 is routed to {@link StreamRateLimitException} and {@code
+   * statusCode} is preserved.
    */
   public static StreamException build(ResponseBody responseBody) {
     ObjectMapper objectMapper = new ObjectMapper();
@@ -68,15 +68,7 @@ public class StreamException extends Exception {
         return apiExceptionFromResponseData(responseData, responseBodyString, status, null);
       } catch (JsonProcessingException e) {
         return new StreamApiException(
-            "failed to parse error response",
-            0,
-            0,
-            null,
-            false,
-            responseBodyString,
-            null,
-            null,
-            e);
+            "failed to parse error response", 0, 0, null, false, responseBodyString, null, null, e);
       }
     } catch (IOException e) {
       return new StreamException(e);
@@ -85,8 +77,8 @@ public class StreamException extends Exception {
 
   /**
    * Builds a typed API exception from an HTTP response. Per CHA-2958 §6.2: 429 → {@link
-   * StreamRateLimitException} with {@code Retry-After} parsed per RFC 7231 §7.1.3 (integer
-   * seconds or HTTP-date). Other 4xx/5xx → {@link StreamApiException}.
+   * StreamRateLimitException} with {@code Retry-After} parsed per RFC 7231 §7.1.3 (integer seconds
+   * or HTTP-date). Other 4xx/5xx → {@link StreamApiException}.
    */
   public static StreamException build(Response httpResponse) {
     int status = httpResponse.code();
@@ -120,10 +112,19 @@ public class StreamException extends Exception {
               : String.format("Unexpected server response code %d", status);
       if (status == 429) {
         return new StreamRateLimitException(
-            msg, status, 0, null, false, bodyString, null, null,
-            RetryAfterParser.parse(httpResponse.header("Retry-After")), parseCause);
+            msg,
+            status,
+            0,
+            null,
+            false,
+            bodyString,
+            null,
+            null,
+            RetryAfterParser.parse(httpResponse.header("Retry-After")),
+            parseCause);
       }
-      return new StreamApiException(msg, status, 0, null, false, bodyString, null, null, parseCause);
+      return new StreamApiException(
+          msg, status, 0, null, false, bodyString, null, null, parseCause);
     }
 
     if (status == 429) {

--- a/src/main/java/io/getstream/exceptions/StreamException.java
+++ b/src/main/java/io/getstream/exceptions/StreamException.java
@@ -29,6 +29,13 @@ public class StreamException extends Exception {
     super(t);
   }
 
+  // Allows subclasses (StreamApiException) to set both the cause and the back-compat responseData
+  // mirror in a single super() call. Package-private: only the exceptions package builds these.
+  StreamException(String message, Throwable cause, ResponseData responseData) {
+    super(message, cause);
+    this.responseData = responseData;
+  }
+
   /**
    * Builds a StreamException to signal an issue
    *
@@ -40,10 +47,15 @@ public class StreamException extends Exception {
   }
 
   /**
-   * Builds a StreamException using the response body when Stream API request fails
+   * Builds a typed API exception from the Stream API error body.
    *
-   * @param responseBody Stream API response body
-   * @return the StreamException
+   * <p>Per CHA-2958 §6.2: parseable {@code APIError} envelope → {@link StreamApiException};
+   * unparseable body but HTTP layer succeeded → {@code StreamApiException} with {@code code=0}
+   * and the raw body preserved (§6.3).
+   *
+   * <p>This overload does not see the status code; callers that have a {@link Response} should
+   * prefer {@link #build(Response)} so 429 is routed to {@link StreamRateLimitException} and
+   * {@code statusCode} is preserved.
    */
   public static StreamException build(ResponseBody responseBody) {
     ObjectMapper objectMapper = new ObjectMapper();
@@ -52,9 +64,19 @@ public class StreamException extends Exception {
       String responseBodyString = responseBody.string();
       try {
         ResponseData responseData = objectMapper.readValue(responseBodyString, ResponseData.class);
-        return new StreamException(responseData.getMessage(), responseData);
+        int status = responseData.getStatusCode() != null ? responseData.getStatusCode() : 0;
+        return apiExceptionFromResponseData(responseData, responseBodyString, status, null);
       } catch (JsonProcessingException e) {
-        return new StreamException(responseBodyString, e);
+        return new StreamApiException(
+            "failed to parse error response",
+            0,
+            0,
+            null,
+            false,
+            responseBodyString,
+            null,
+            null,
+            e);
       }
     } catch (IOException e) {
       return new StreamException(e);
@@ -62,40 +84,92 @@ public class StreamException extends Exception {
   }
 
   /**
-   * Builds a StreamException based on response from the server and http code
-   *
-   * @param httpResponse Stream API response
-   * @return the StreamException
+   * Builds a typed API exception from an HTTP response. Per CHA-2958 §6.2: 429 → {@link
+   * StreamRateLimitException} with {@code Retry-After} parsed per RFC 7231 §7.1.3 (integer
+   * seconds or HTTP-date). Other 4xx/5xx → {@link StreamApiException}.
    */
   public static StreamException build(Response httpResponse) {
-    StreamException exception;
+    int status = httpResponse.code();
+    String bodyString = "";
+    ResponseData parsed = null;
+    Throwable parseCause = null;
 
     ResponseBody errorBody = httpResponse.body();
     if (errorBody != null) {
-      exception = StreamException.build(errorBody);
-    } else {
-      exception =
-          StreamException.build(
-              String.format("Unexpected server response code %d", httpResponse.code()));
+      try {
+        bodyString = errorBody.string();
+      } catch (IOException e) {
+        // Body unreadable — treat as empty.
+        parseCause = e;
+      }
+      if (!bodyString.isEmpty()) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        try {
+          parsed = objectMapper.readValue(bodyString, ResponseData.class);
+        } catch (JsonProcessingException e) {
+          parseCause = e;
+        }
+      }
     }
 
-    if (exception.responseData == null) {
-      ResponseData responseData = new ResponseData();
-      responseData.statusCode = httpResponse.code();
-      exception.responseData = responseData;
+    if (parsed == null) {
+      String msg =
+          parseCause != null
+              ? "failed to parse error response"
+              : String.format("Unexpected server response code %d", status);
+      if (status == 429) {
+        return new StreamRateLimitException(
+            msg, status, 0, null, false, bodyString, null, null,
+            RetryAfterParser.parse(httpResponse.header("Retry-After")), parseCause);
+      }
+      return new StreamApiException(msg, status, 0, null, false, bodyString, null, null, parseCause);
     }
 
-    return exception;
+    if (status == 429) {
+      return new StreamRateLimitException(
+          parsed.getMessage() != null ? parsed.getMessage() : "rate limited",
+          status,
+          parsed.getCode() != null ? parsed.getCode() : 0,
+          parsed.getExceptionFields(),
+          parsed.getUnrecoverable() != null ? parsed.getUnrecoverable() : false,
+          bodyString,
+          parsed.getMoreInfo(),
+          parsed.getDetails(),
+          RetryAfterParser.parse(httpResponse.header("Retry-After")),
+          null);
+    }
+    return apiExceptionFromResponseData(parsed, bodyString, status, null);
   }
 
   /**
-   * Builds a StreamException when an exception occurs calling the API
+   * Builds a StreamException when an exception occurs calling the API.
+   *
+   * <p>Historic factory preserved for back-compat. The HTTP-call path now classifies transport
+   * failures directly via {@link StreamTransportException#fromIOException(IOException)} so this
+   * factory no longer auto-routes; it simply wraps the cause.
    *
    * @param t the underlying exception
    * @return the StreamException
    */
   public static StreamException build(Throwable t) {
     return new StreamException(t);
+  }
+
+  // statusCode comes from the HTTP layer (§5.1: "Source: HTTP status"). The envelope's
+  // StatusCode is only used as a fallback by build(ResponseBody), which has no live response.
+  private static StreamApiException apiExceptionFromResponseData(
+      ResponseData rd, String rawBody, int statusCode, Throwable cause) {
+    return new StreamApiException(
+        rd.getMessage() != null ? rd.getMessage() : "",
+        statusCode,
+        rd.getCode() != null ? rd.getCode() : 0,
+        rd.getExceptionFields(),
+        rd.getUnrecoverable() != null ? rd.getUnrecoverable() : false,
+        rawBody != null ? rawBody : "",
+        rd.getMoreInfo(),
+        rd.getDetails(),
+        cause);
   }
 
   @Data
@@ -117,5 +191,11 @@ public class StreamException extends Exception {
 
     @JsonProperty("more_info")
     private String moreInfo;
+
+    @JsonProperty("details")
+    private Object details;
+
+    @JsonProperty("unrecoverable")
+    private Boolean unrecoverable;
   }
 }

--- a/src/main/java/io/getstream/exceptions/StreamRateLimitException.java
+++ b/src/main/java/io/getstream/exceptions/StreamRateLimitException.java
@@ -1,0 +1,41 @@
+package io.getstream.exceptions;
+
+import java.time.Duration;
+import java.util.Map;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Thrown when the Stream API returns HTTP 429. Subclass of {@link StreamApiException} that
+ * additionally carries the parsed {@code Retry-After} header (RFC 7231 §7.1.3 — integer seconds
+ * or HTTP-date). Per CHA-2958 §5.2.
+ */
+public class StreamRateLimitException extends StreamApiException {
+  private static final long serialVersionUID = 1L;
+
+  @Nullable private final Duration retryAfter;
+
+  public StreamRateLimitException(
+      String message,
+      int statusCode,
+      int code,
+      @Nullable Map<String, String> exceptionFields,
+      boolean unrecoverable,
+      String rawResponseBody,
+      @Nullable String moreInfo,
+      @Nullable Object details,
+      @Nullable Duration retryAfter,
+      @Nullable Throwable cause) {
+    super(message, statusCode, code, exceptionFields, unrecoverable, rawResponseBody, moreInfo,
+        details, cause);
+    this.retryAfter = retryAfter;
+  }
+
+  /**
+   * Returns the {@code Retry-After} delta if the server sent a parseable value. {@code null}
+   * when the header was absent or unparseable.
+   */
+  @Nullable
+  public Duration getRetryAfter() {
+    return retryAfter;
+  }
+}

--- a/src/main/java/io/getstream/exceptions/StreamRateLimitException.java
+++ b/src/main/java/io/getstream/exceptions/StreamRateLimitException.java
@@ -6,8 +6,8 @@ import org.jetbrains.annotations.Nullable;
 
 /**
  * Thrown when the Stream API returns HTTP 429. Subclass of {@link StreamApiException} that
- * additionally carries the parsed {@code Retry-After} header (RFC 7231 §7.1.3 — integer seconds
- * or HTTP-date). Per CHA-2958 §5.2.
+ * additionally carries the parsed {@code Retry-After} header (RFC 7231 §7.1.3 — integer seconds or
+ * HTTP-date). Per CHA-2958 §5.2.
  */
 public class StreamRateLimitException extends StreamApiException {
   private static final long serialVersionUID = 1L;
@@ -25,14 +25,22 @@ public class StreamRateLimitException extends StreamApiException {
       @Nullable Object details,
       @Nullable Duration retryAfter,
       @Nullable Throwable cause) {
-    super(message, statusCode, code, exceptionFields, unrecoverable, rawResponseBody, moreInfo,
-        details, cause);
+    super(
+        message,
+        statusCode,
+        code,
+        exceptionFields,
+        unrecoverable,
+        rawResponseBody,
+        moreInfo,
+        details,
+        cause);
     this.retryAfter = retryAfter;
   }
 
   /**
-   * Returns the {@code Retry-After} delta if the server sent a parseable value. {@code null}
-   * when the header was absent or unparseable.
+   * Returns the {@code Retry-After} delta if the server sent a parseable value. {@code null} when
+   * the header was absent or unparseable.
    */
   @Nullable
   public Duration getRetryAfter() {

--- a/src/main/java/io/getstream/exceptions/StreamRateLimitException.java
+++ b/src/main/java/io/getstream/exceptions/StreamRateLimitException.java
@@ -7,7 +7,7 @@ import org.jetbrains.annotations.Nullable;
 /**
  * Thrown when the Stream API returns HTTP 429. Subclass of {@link StreamApiException} that
  * additionally carries the parsed {@code Retry-After} header (RFC 7231 §7.1.3 — integer seconds or
- * HTTP-date). Per CHA-2958 §5.2.
+ * HTTP-date).
  */
 public class StreamRateLimitException extends StreamApiException {
   private static final long serialVersionUID = 1L;

--- a/src/main/java/io/getstream/exceptions/StreamTaskException.java
+++ b/src/main/java/io/getstream/exceptions/StreamTaskException.java
@@ -47,9 +47,8 @@ public class StreamTaskException extends StreamException {
   }
 
   /**
-   * Returns the server-side stack trace from {@code ErrorResult.stacktrace}, or {@code null}.
-   * Named {@code getStackTraceText} so it does not collide with
-   * {@link Throwable#getStackTrace()}.
+   * Returns the server-side stack trace from {@code ErrorResult.stacktrace}, or {@code null}. Named
+   * {@code getStackTraceText} so it does not collide with {@link Throwable#getStackTrace()}.
    */
   @Nullable
   public String getStackTraceText() {

--- a/src/main/java/io/getstream/exceptions/StreamTaskException.java
+++ b/src/main/java/io/getstream/exceptions/StreamTaskException.java
@@ -4,7 +4,7 @@ import org.jetbrains.annotations.Nullable;
 
 /**
  * Thrown when an async task observed via {@code waitForTask} reaches {@code status: "failed"}.
- * Populated from the task's {@code ErrorResult}. Per CHA-2958 §5.4.
+ * Populated from the task's {@code ErrorResult}.
  */
 public class StreamTaskException extends StreamException {
   private static final long serialVersionUID = 1L;

--- a/src/main/java/io/getstream/exceptions/StreamTaskException.java
+++ b/src/main/java/io/getstream/exceptions/StreamTaskException.java
@@ -1,0 +1,63 @@
+package io.getstream.exceptions;
+
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Thrown when an async task observed via {@code waitForTask} reaches {@code status: "failed"}.
+ * Populated from the task's {@code ErrorResult}. Per CHA-2958 §5.4.
+ */
+public class StreamTaskException extends StreamException {
+  private static final long serialVersionUID = 1L;
+
+  private final String taskId;
+  private final String errorType;
+  private final String description;
+  @Nullable private final String stackTraceText;
+  @Nullable private final String version;
+
+  public StreamTaskException(
+      String taskId,
+      String errorType,
+      String description,
+      @Nullable String stackTraceText,
+      @Nullable String version) {
+    super(buildMessage(taskId, errorType, description), (Throwable) null);
+    this.taskId = taskId;
+    this.errorType = errorType;
+    this.description = description;
+    this.stackTraceText = stackTraceText;
+    this.version = version;
+  }
+
+  private static String buildMessage(String taskId, String errorType, String description) {
+    return String.format(
+        "task %s failed: %s%s", taskId, errorType, description != null ? " — " + description : "");
+  }
+
+  public String getTaskId() {
+    return taskId;
+  }
+
+  public String getErrorType() {
+    return errorType;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  /**
+   * Returns the server-side stack trace from {@code ErrorResult.stacktrace}, or {@code null}.
+   * Named {@code getStackTraceText} so it does not collide with
+   * {@link Throwable#getStackTrace()}.
+   */
+  @Nullable
+  public String getStackTraceText() {
+    return stackTraceText;
+  }
+
+  @Nullable
+  public String getVersion() {
+    return version;
+  }
+}

--- a/src/main/java/io/getstream/exceptions/StreamTransportException.java
+++ b/src/main/java/io/getstream/exceptions/StreamTransportException.java
@@ -11,8 +11,7 @@ import javax.net.ssl.SSLException;
 /**
  * Thrown when a network-layer failure prevents the SDK from receiving an HTTP response. Carries an
  * {@link #getErrorType()} string matching the logging spec §6.4 enum: {@code connection_reset},
- * {@code timeout}, {@code dns_failure}, {@code tls_handshake_failed}, {@code unknown}. Per CHA-2958
- * §5.3 / §6.1.
+ * {@code timeout}, {@code dns_failure}, {@code tls_handshake_failed}, {@code unknown}.
  *
  * <p>The original transport error is preserved on the cause chain ({@link Throwable#getCause()}).
  */
@@ -52,8 +51,6 @@ public class StreamTransportException extends StreamException {
   }
 
   private static String classify(IOException e) {
-    // TLS first: SSLException is a subclass of IOException, and SSLHandshakeException is a
-    // subclass of SSLException — both flow through here.
     if (e instanceof SSLException) {
       return TLS_HANDSHAKE_FAILED;
     }
@@ -63,15 +60,12 @@ public class StreamTransportException extends StreamException {
     if (e instanceof SocketTimeoutException) {
       return TIMEOUT;
     }
-    // OkHttp's call-timeout path raises a plain InterruptedIOException with message "timeout".
     if (e instanceof InterruptedIOException) {
       return TIMEOUT;
     }
     if (e instanceof ConnectException || e instanceof NoRouteToHostException) {
       return CONNECTION_RESET;
     }
-    // "Connection reset" / "Broken pipe" surface as a vanilla IOException with that message on
-    // some JVMs. Match by message as a last-resort heuristic before falling through to unknown.
     String msg = e.getMessage();
     if (msg != null) {
       String lower = msg.toLowerCase();

--- a/src/main/java/io/getstream/exceptions/StreamTransportException.java
+++ b/src/main/java/io/getstream/exceptions/StreamTransportException.java
@@ -1,0 +1,91 @@
+package io.getstream.exceptions;
+
+import java.io.IOException;
+import java.io.InterruptedIOException;
+import java.net.ConnectException;
+import java.net.NoRouteToHostException;
+import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
+import javax.net.ssl.SSLException;
+
+/**
+ * Thrown when a network-layer failure prevents the SDK from receiving an HTTP response.
+ * Carries an {@link #getErrorType()} string matching the logging spec §6.4 enum:
+ * {@code connection_reset}, {@code timeout}, {@code dns_failure},
+ * {@code tls_handshake_failed}, {@code unknown}. Per CHA-2958 §5.3 / §6.1.
+ *
+ * <p>The original transport error is preserved on the cause chain ({@link Throwable#getCause()}).
+ */
+public class StreamTransportException extends StreamException {
+  private static final long serialVersionUID = 1L;
+
+  public static final String CONNECTION_RESET = "connection_reset";
+  public static final String TIMEOUT = "timeout";
+  public static final String DNS_FAILURE = "dns_failure";
+  public static final String TLS_HANDSHAKE_FAILED = "tls_handshake_failed";
+  public static final String UNKNOWN = "unknown";
+
+  private final String errorType;
+
+  public StreamTransportException(String errorType, String message, Throwable cause) {
+    super(message, cause);
+    this.errorType = errorType;
+  }
+
+  public StreamTransportException(String errorType, Throwable cause) {
+    super(cause);
+    this.errorType = errorType;
+  }
+
+  public String getErrorType() {
+    return errorType;
+  }
+
+  /**
+   * Classifies an {@link IOException} from the HTTP client into one of the {@code errorType}
+   * enum values. The OkHttp call-timeout path throws {@link InterruptedIOException} with the
+   * message "timeout", so that is mapped to {@link #TIMEOUT} alongside
+   * {@link SocketTimeoutException}.
+   */
+  public static StreamTransportException fromIOException(IOException e) {
+    String type = classify(e);
+    return new StreamTransportException(type, e.getMessage(), e);
+  }
+
+  private static String classify(IOException e) {
+    // TLS first: SSLException is a subclass of IOException, and SSLHandshakeException is a
+    // subclass of SSLException — both flow through here.
+    if (e instanceof SSLException) {
+      return TLS_HANDSHAKE_FAILED;
+    }
+    if (e instanceof UnknownHostException) {
+      return DNS_FAILURE;
+    }
+    if (e instanceof SocketTimeoutException) {
+      return TIMEOUT;
+    }
+    // OkHttp's call-timeout path raises a plain InterruptedIOException with message "timeout".
+    if (e instanceof InterruptedIOException) {
+      return TIMEOUT;
+    }
+    if (e instanceof ConnectException || e instanceof NoRouteToHostException) {
+      return CONNECTION_RESET;
+    }
+    // "Connection reset" / "Broken pipe" surface as a vanilla IOException with that message on
+    // some JVMs. Match by message as a last-resort heuristic before falling through to unknown.
+    String msg = e.getMessage();
+    if (msg != null) {
+      String lower = msg.toLowerCase();
+      if (lower.contains("connection reset")
+          || lower.contains("connection refused")
+          || lower.contains("connection closed")
+          || lower.contains("broken pipe")) {
+        return CONNECTION_RESET;
+      }
+      if (lower.contains("timeout") || lower.contains("timed out")) {
+        return TIMEOUT;
+      }
+    }
+    return UNKNOWN;
+  }
+}

--- a/src/main/java/io/getstream/exceptions/StreamTransportException.java
+++ b/src/main/java/io/getstream/exceptions/StreamTransportException.java
@@ -9,10 +9,10 @@ import java.net.UnknownHostException;
 import javax.net.ssl.SSLException;
 
 /**
- * Thrown when a network-layer failure prevents the SDK from receiving an HTTP response.
- * Carries an {@link #getErrorType()} string matching the logging spec §6.4 enum:
- * {@code connection_reset}, {@code timeout}, {@code dns_failure},
- * {@code tls_handshake_failed}, {@code unknown}. Per CHA-2958 §5.3 / §6.1.
+ * Thrown when a network-layer failure prevents the SDK from receiving an HTTP response. Carries an
+ * {@link #getErrorType()} string matching the logging spec §6.4 enum: {@code connection_reset},
+ * {@code timeout}, {@code dns_failure}, {@code tls_handshake_failed}, {@code unknown}. Per CHA-2958
+ * §5.3 / §6.1.
  *
  * <p>The original transport error is preserved on the cause chain ({@link Throwable#getCause()}).
  */
@@ -42,10 +42,9 @@ public class StreamTransportException extends StreamException {
   }
 
   /**
-   * Classifies an {@link IOException} from the HTTP client into one of the {@code errorType}
-   * enum values. The OkHttp call-timeout path throws {@link InterruptedIOException} with the
-   * message "timeout", so that is mapped to {@link #TIMEOUT} alongside
-   * {@link SocketTimeoutException}.
+   * Classifies an {@link IOException} from the HTTP client into one of the {@code errorType} enum
+   * values. The OkHttp call-timeout path throws {@link InterruptedIOException} with the message
+   * "timeout", so that is mapped to {@link #TIMEOUT} alongside {@link SocketTimeoutException}.
    */
   public static StreamTransportException fromIOException(IOException e) {
     String type = classify(e);

--- a/src/main/java/io/getstream/services/framework/StreamHTTPClient.java
+++ b/src/main/java/io/getstream/services/framework/StreamHTTPClient.java
@@ -230,9 +230,15 @@ public class StreamHTTPClient {
       options.setIdleTimeout(Duration.ofSeconds(connectionMaxAgeSeconds));
     }
 
-    var envApiUrl = env.getOrDefault("STREAM_BASE_URL", System.getProperty(API_URL_PROP_NAME));
-    if (envApiUrl != null) {
-      this.baseUrl = envApiUrl;
+    // Treat an empty STREAM_BASE_URL env var as unset (a common CI pattern: `STREAM_BASE_URL:
+    // ${{ vars.STREAM_BASE_URL }}` renders to empty when the variable is unset). Empty would
+    // otherwise wipe out any io.getstream.url system property set by tests.
+    var envBaseUrl = env.get("STREAM_BASE_URL");
+    if (envBaseUrl == null || envBaseUrl.isBlank()) {
+      envBaseUrl = System.getProperty(API_URL_PROP_NAME);
+    }
+    if (envBaseUrl != null && !envBaseUrl.isBlank()) {
+      this.baseUrl = envBaseUrl;
     }
   }
 

--- a/src/main/java/io/getstream/services/framework/StreamRequest.java
+++ b/src/main/java/io/getstream/services/framework/StreamRequest.java
@@ -254,7 +254,7 @@ public class StreamRequest<T> {
     try {
       response = call.execute();
     } catch (IOException e) {
-      // Transport-layer failure (connection reset, timeout, DNS, TLS). CHA-2958 §6.1.
+      // IO failure: classify and re-throw as StreamTransportException.
       throw StreamTransportException.fromIOException(e);
     }
 
@@ -263,7 +263,7 @@ public class StreamRequest<T> {
 
   private StreamResponse<T> parseResponse(okhttp3.Response response) throws StreamException {
     if (!response.isSuccessful()) {
-      // 4xx/5xx → StreamApiException (or StreamRateLimitException for 429). CHA-2958 §6.2.
+      // 4xx/5xx → StreamApiException (StreamRateLimitException for 429).
       throw StreamException.build(response);
     }
     ResponseBody rawBody = response.body();
@@ -272,7 +272,7 @@ public class StreamRequest<T> {
     try {
       bodyStr = rawBody.string();
     } catch (IOException e) {
-      // Body read failed mid-stream — that's a transport problem, not a parse problem.
+      // Body read failure is transport, not parse.
       throw StreamTransportException.fromIOException(e);
     }
     T result;

--- a/src/main/java/io/getstream/services/framework/StreamRequest.java
+++ b/src/main/java/io/getstream/services/framework/StreamRequest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.getstream.exceptions.StreamException;
+import io.getstream.exceptions.StreamTransportException;
 import io.getstream.models.UploadChannelFileRequest;
 import io.getstream.models.UploadChannelImageRequest;
 import io.getstream.models.UploadFileRequest;
@@ -253,7 +254,8 @@ public class StreamRequest<T> {
     try {
       response = call.execute();
     } catch (IOException e) {
-      throw StreamException.build(e);
+      // Transport-layer failure (connection reset, timeout, DNS, TLS). CHA-2958 §6.1.
+      throw StreamTransportException.fromIOException(e);
     }
 
     return this.parseResponse(response);
@@ -261,15 +263,23 @@ public class StreamRequest<T> {
 
   private StreamResponse<T> parseResponse(okhttp3.Response response) throws StreamException {
     if (!response.isSuccessful()) {
+      // 4xx/5xx → StreamApiException (or StreamRateLimitException for 429). CHA-2958 §6.2.
       throw StreamException.build(response);
     }
     ResponseBody rawBody = response.body();
     // unmarshal the response body to the expected type using jackson
+    String bodyStr;
+    try {
+      bodyStr = rawBody.string();
+    } catch (IOException e) {
+      // Body read failed mid-stream — that's a transport problem, not a parse problem.
+      throw StreamTransportException.fromIOException(e);
+    }
     T result;
     try {
-      result = objectMapper.readValue(rawBody.string(), typeReference);
+      result = objectMapper.readValue(bodyStr, typeReference);
     } catch (Throwable e) {
-      throw StreamException.build(e);
+      throw new StreamException("failed to parse response body", e);
     }
 
     StreamResponse<T> streamResponse = new StreamResponse<>();

--- a/src/main/java/io/getstream/services/framework/StreamSDKClient.java
+++ b/src/main/java/io/getstream/services/framework/StreamSDKClient.java
@@ -1,6 +1,12 @@
 package io.getstream.services.framework;
 
+import io.getstream.exceptions.StreamException;
+import io.getstream.exceptions.StreamTaskException;
+import io.getstream.exceptions.StreamTransportException;
+import io.getstream.models.ErrorResult;
+import io.getstream.models.GetTaskResponse;
 import io.getstream.services.*;
+import java.time.Duration;
 import java.util.Properties;
 import okhttp3.OkHttpClient;
 import org.jetbrains.annotations.NotNull;
@@ -119,5 +125,81 @@ public class StreamSDKClient extends CommonImpl implements Common {
    */
   public Object parseSns(String notificationBody) throws io.getstream.Webhook.InvalidWebhookError {
     return io.getstream.Webhook.parseSns(notificationBody);
+  }
+
+  /** Default poll interval for {@link #waitForTask(String)}. */
+  private static final Duration DEFAULT_TASK_POLL_INTERVAL = Duration.ofSeconds(1);
+
+  /** Default max wait for {@link #waitForTask(String)}. */
+  private static final Duration DEFAULT_TASK_TIMEOUT = Duration.ofSeconds(60);
+
+  /**
+   * Polls {@code getTask(taskId)} until the task reaches a terminal status (per CHA-2958 §8).
+   * Uses a 1-second poll interval and a 60-second timeout.
+   *
+   * @return the terminal {@link GetTaskResponse} when {@code status == "completed"}
+   * @throws StreamTaskException if the task ends with {@code status == "failed"}
+   * @throws StreamTransportException with {@code errorType == "timeout"} if the wait elapses
+   * @throws StreamException for any other underlying transport / API failure
+   */
+  @NotNull
+  public GetTaskResponse waitForTask(@NotNull String taskId) throws StreamException {
+    return waitForTask(taskId, DEFAULT_TASK_POLL_INTERVAL, DEFAULT_TASK_TIMEOUT);
+  }
+
+  /**
+   * Polls {@code getTask(taskId)} until the task reaches a terminal status (per CHA-2958 §8).
+   *
+   * @param taskId the task identifier returned by the operation that enqueued the task
+   * @param pollInterval delay between polls; clamped to a non-negative value
+   * @param timeout max total wait; the timeout window starts before the first poll
+   * @throws StreamTaskException if the task ends with {@code status == "failed"}
+   * @throws StreamTransportException with {@code errorType == "timeout"} if the wait elapses
+   * @throws StreamException for any other underlying transport / API failure
+   */
+  @NotNull
+  public GetTaskResponse waitForTask(
+      @NotNull String taskId, @NotNull Duration pollInterval, @NotNull Duration timeout)
+      throws StreamException {
+    if (pollInterval.isNegative()) {
+      throw new IllegalArgumentException(
+          "pollInterval must be non-negative, got " + pollInterval);
+    }
+    if (timeout.isNegative()) {
+      throw new IllegalArgumentException("timeout must be non-negative, got " + timeout);
+    }
+    long deadlineNanos = System.nanoTime() + timeout.toNanos();
+    long pollMillis = Math.max(0L, pollInterval.toMillis());
+    while (true) {
+      GetTaskResponse data = this.getTask(taskId).execute().getData();
+      String status = data.getStatus();
+      if ("completed".equals(status)) {
+        return data;
+      }
+      if ("failed".equals(status)) {
+        ErrorResult err = data.getError();
+        throw new StreamTaskException(
+            taskId,
+            err != null && err.getType() != null ? err.getType() : "",
+            err != null && err.getDescription() != null ? err.getDescription() : "",
+            err != null ? err.getStacktrace() : null,
+            err != null ? err.getVersion() : null);
+      }
+      if (System.nanoTime() >= deadlineNanos) {
+        throw new StreamTransportException(
+            StreamTransportException.TIMEOUT,
+            "timed out waiting for task " + taskId + " after " + timeout,
+            null);
+      }
+      if (pollMillis > 0) {
+        try {
+          Thread.sleep(pollMillis);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw new StreamTransportException(
+              StreamTransportException.TIMEOUT, "interrupted while polling task " + taskId, e);
+        }
+      }
+    }
   }
 }

--- a/src/main/java/io/getstream/services/framework/StreamSDKClient.java
+++ b/src/main/java/io/getstream/services/framework/StreamSDKClient.java
@@ -134,8 +134,8 @@ public class StreamSDKClient extends CommonImpl implements Common {
   private static final Duration DEFAULT_TASK_TIMEOUT = Duration.ofSeconds(60);
 
   /**
-   * Polls {@code getTask(taskId)} until the task reaches a terminal status (per CHA-2958 §8).
-   * Uses a 1-second poll interval and a 60-second timeout.
+   * Polls {@code getTask(taskId)} until the task reaches a terminal status (per CHA-2958 §8). Uses
+   * a 1-second poll interval and a 60-second timeout.
    *
    * @return the terminal {@link GetTaskResponse} when {@code status == "completed"}
    * @throws StreamTaskException if the task ends with {@code status == "failed"}
@@ -162,8 +162,7 @@ public class StreamSDKClient extends CommonImpl implements Common {
       @NotNull String taskId, @NotNull Duration pollInterval, @NotNull Duration timeout)
       throws StreamException {
     if (pollInterval.isNegative()) {
-      throw new IllegalArgumentException(
-          "pollInterval must be non-negative, got " + pollInterval);
+      throw new IllegalArgumentException("pollInterval must be non-negative, got " + pollInterval);
     }
     if (timeout.isNegative()) {
       throw new IllegalArgumentException("timeout must be non-negative, got " + timeout);

--- a/src/main/java/io/getstream/services/framework/StreamSDKClient.java
+++ b/src/main/java/io/getstream/services/framework/StreamSDKClient.java
@@ -134,8 +134,8 @@ public class StreamSDKClient extends CommonImpl implements Common {
   private static final Duration DEFAULT_TASK_TIMEOUT = Duration.ofSeconds(60);
 
   /**
-   * Polls {@code getTask(taskId)} until the task reaches a terminal status (per CHA-2958 §8). Uses
-   * a 1-second poll interval and a 60-second timeout.
+   * Polls {@code getTask(taskId)} until the task reaches a terminal status. Uses a 1-second poll
+   * interval and a 60-second timeout.
    *
    * @return the terminal {@link GetTaskResponse} when {@code status == "completed"}
    * @throws StreamTaskException if the task ends with {@code status == "failed"}
@@ -148,7 +148,7 @@ public class StreamSDKClient extends CommonImpl implements Common {
   }
 
   /**
-   * Polls {@code getTask(taskId)} until the task reaches a terminal status (per CHA-2958 §8).
+   * Polls {@code getTask(taskId)} until the task reaches a terminal status.
    *
    * @param taskId the task identifier returned by the operation that enqueued the task
    * @param pollInterval delay between polls; clamped to a non-negative value

--- a/src/test/java/io/getstream/ChatChannelIntegrationTest.java
+++ b/src/test/java/io/getstream/ChatChannelIntegrationTest.java
@@ -420,7 +420,7 @@ class ChatChannelIntegrationTest extends ChatTestBase {
     assertFalse(taskId.isEmpty(), "TaskID should not be empty");
 
     // Poll task until completed
-    waitForTask(taskId);
+    client.waitForTask(taskId);
   }
 
   @Test

--- a/src/test/java/io/getstream/ChatMiscIntegrationTest.java
+++ b/src/test/java/io/getstream/ChatMiscIntegrationTest.java
@@ -440,7 +440,7 @@ class ChatMiscIntegrationTest extends ChatTestBase {
 
       // Poll task until completed
       String taskId = exportResp.getData().getTaskID();
-      waitForTask(taskId);
+      client.waitForTask(taskId);
 
     } finally {
       try {
@@ -902,7 +902,7 @@ class ChatMiscIntegrationTest extends ChatTestBase {
       // If an async task ID is returned, poll until completion
       String taskId = resp.getData().getTaskID();
       if (taskId != null && !taskId.isEmpty()) {
-        waitForTask(taskId);
+        client.waitForTask(taskId);
       }
 
     } catch (io.getstream.exceptions.StreamException e) {

--- a/src/test/java/io/getstream/ChatTestBase.java
+++ b/src/test/java/io/getstream/ChatTestBase.java
@@ -111,20 +111,6 @@ public class ChatTestBase extends BasicTest {
     }
   }
 
-  /**
-   * Polls the given task ID until it reaches "completed" or "failed" status. Polls up to 30 times
-   * with 1-second intervals.
-   */
-  protected void waitForTask(String taskId) throws Exception {
-    for (int i = 0; i < 30; i++) {
-      var result = client.getTask(taskId).execute();
-      String status = result.getData().getStatus();
-      if ("completed".equals(status) || "failed".equals(status)) return;
-      Thread.sleep(1000);
-    }
-    Assertions.fail("Task " + taskId + " did not complete after 30 attempts");
-  }
-
   /** Generates a random lowercase alphanumeric string of the given length. */
   protected String randomString(int n) {
     return RandomStringUtils.randomAlphanumeric(n).toLowerCase();

--- a/src/test/java/io/getstream/ChatUserIntegrationTest.java
+++ b/src/test/java/io/getstream/ChatUserIntegrationTest.java
@@ -201,7 +201,7 @@ class ChatUserIntegrationTest extends ChatTestBase {
     }
 
     assertNotNull(taskId, "Delete users should return a task ID");
-    waitForTask(taskId);
+    client.waitForTask(taskId);
   }
 
   @Test
@@ -616,7 +616,7 @@ class ChatUserIntegrationTest extends ChatTestBase {
     assertNotNull(taskId, "DeactivateUsers should return a task ID");
 
     // Poll until completed
-    waitForTask(taskId);
+    client.waitForTask(taskId);
 
     // Verify users are deactivated (not visible without includeDeactivatedUsers)
     var queryResp =

--- a/src/test/java/io/getstream/StreamErrorHandlingTest.java
+++ b/src/test/java/io/getstream/StreamErrorHandlingTest.java
@@ -48,7 +48,7 @@ class StreamErrorHandlingTest {
     server.shutdown();
   }
 
-  private StreamRequest<Map<String, Object>> request() {
+  private StreamRequest<Map<String, Object>> request() throws StreamException {
     return new StreamRequest<>(
         http.getHttpClient(),
         http.getObjectMapper(),
@@ -213,7 +213,10 @@ class StreamErrorHandlingTest {
     assertTrue(e instanceof StreamApiException);
     assertEquals(401, ((StreamApiException) e).getStatusCode());
     // The base StreamException stays as a checked Exception — explicitly verified.
+    // Use Class#isInstance to bypass the JDK 21 unconditional-instanceof compile error
+    // (StreamException is statically incompatible with RuntimeException).
     assertFalse(
-        e instanceof RuntimeException, "Java SDK keeps exceptions checked per CHA-2958 §9.3");
+        RuntimeException.class.isInstance(e),
+        "Java SDK keeps exceptions checked per CHA-2958 §9.3");
   }
 }

--- a/src/test/java/io/getstream/StreamErrorHandlingTest.java
+++ b/src/test/java/io/getstream/StreamErrorHandlingTest.java
@@ -121,7 +121,8 @@ class StreamErrorHandlingTest {
             .setBody("{\"code\":9,\"message\":\"Too many requests\",\"StatusCode\":429}"));
 
     StreamException raw = assertThrows(StreamException.class, () -> request().execute());
-    assertTrue(raw instanceof StreamRateLimitException, "429 must produce StreamRateLimitException");
+    assertTrue(
+        raw instanceof StreamRateLimitException, "429 must produce StreamRateLimitException");
     StreamRateLimitException e = (StreamRateLimitException) raw;
     assertEquals(429, e.getStatusCode());
     assertEquals(Duration.ofSeconds(30), e.getRetryAfter());

--- a/src/test/java/io/getstream/StreamErrorHandlingTest.java
+++ b/src/test/java/io/getstream/StreamErrorHandlingTest.java
@@ -1,0 +1,218 @@
+package io.getstream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.getstream.exceptions.StreamApiException;
+import io.getstream.exceptions.StreamException;
+import io.getstream.exceptions.StreamRateLimitException;
+import io.getstream.exceptions.StreamTransportException;
+import io.getstream.services.framework.StreamClientOptions;
+import io.getstream.services.framework.StreamHTTPClient;
+import io.getstream.services.framework.StreamRequest;
+import java.io.IOException;
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.SocketPolicy;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers CHA-2958 error-handling spec for the request/response path: HTTP errors map to {@link
+ * StreamApiException} / {@link StreamRateLimitException}, IO failures map to {@link
+ * StreamTransportException}, and the existing {@link StreamException} base remains catchable.
+ */
+class StreamErrorHandlingTest {
+  private MockWebServer server;
+  private StreamHTTPClient http;
+
+  @BeforeEach
+  void start() throws IOException {
+    server = new MockWebServer();
+    server.start();
+    http =
+        new StreamHTTPClient(
+            "apiKey",
+            "012345678901234567890123456789ab",
+            new StreamClientOptions().setRequestTimeout(Duration.ofSeconds(5)));
+  }
+
+  @AfterEach
+  void stop() throws IOException {
+    server.shutdown();
+  }
+
+  private StreamRequest<Map<String, Object>> request() {
+    return new StreamRequest<>(
+        http.getHttpClient(),
+        http.getObjectMapper(),
+        server.url("/").toString(),
+        "GET",
+        "ping",
+        null,
+        null,
+        new TypeReference<Map<String, Object>>() {});
+  }
+
+  @Test
+  void api4xxParsed_populatesAllEnvelopeFields() {
+    String body =
+        "{"
+            + "\"code\":17,"
+            + "\"message\":\"forbidden\","
+            + "\"StatusCode\":403,"
+            + "\"exception_fields\":{\"user_id\":\"required\"},"
+            + "\"more_info\":\"https://example.com/help\","
+            + "\"unrecoverable\":true,"
+            + "\"details\":{\"reason\":\"banned\"}"
+            + "}";
+    server.enqueue(new MockResponse().setResponseCode(403).setBody(body));
+
+    StreamApiException e = assertThrows(StreamApiException.class, () -> request().execute());
+    assertEquals(403, e.getStatusCode());
+    assertEquals(17, e.getCode());
+    assertEquals("forbidden", e.getMessage());
+    assertEquals(Map.of("user_id", "required"), e.getExceptionFields());
+    assertTrue(e.isUnrecoverable(), "unrecoverable flag must be extracted");
+    assertEquals("https://example.com/help", e.getMoreInfo());
+    assertNotNull(e.getDetails(), "details must be extracted");
+    assertEquals(body, e.getRawResponseBody());
+  }
+
+  @Test
+  void api5xxParsed_populatesEnvelopeAndStatusCode() {
+    server.enqueue(
+        new MockResponse()
+            .setResponseCode(500)
+            .setBody("{\"code\":1,\"message\":\"internal\",\"StatusCode\":500}"));
+
+    StreamApiException e = assertThrows(StreamApiException.class, () -> request().execute());
+    assertEquals(500, e.getStatusCode());
+    assertEquals(1, e.getCode());
+    assertEquals("internal", e.getMessage());
+    assertFalse(e.isUnrecoverable(), "missing unrecoverable defaults to false");
+    assertTrue(e.getExceptionFields().isEmpty(), "missing exception_fields → empty map");
+  }
+
+  @Test
+  void apiUnparseableBody_setsRawBodyAndZeroCode() {
+    server.enqueue(new MockResponse().setResponseCode(502).setBody("<html>bad gateway</html>"));
+
+    StreamApiException e = assertThrows(StreamApiException.class, () -> request().execute());
+    assertEquals(502, e.getStatusCode(), "status code preserved when body is unparseable");
+    assertEquals(0, e.getCode(), "unparseable body → code 0");
+    assertEquals("failed to parse error response", e.getMessage());
+    assertEquals("<html>bad gateway</html>", e.getRawResponseBody());
+    assertNotNull(e.getCause(), "parse error preserved on cause chain");
+  }
+
+  @Test
+  void rateLimit429_integerSecondsHeader() {
+    server.enqueue(
+        new MockResponse()
+            .setResponseCode(429)
+            .setHeader("Retry-After", "30")
+            .setBody("{\"code\":9,\"message\":\"Too many requests\",\"StatusCode\":429}"));
+
+    StreamException raw = assertThrows(StreamException.class, () -> request().execute());
+    assertTrue(raw instanceof StreamRateLimitException, "429 must produce StreamRateLimitException");
+    StreamRateLimitException e = (StreamRateLimitException) raw;
+    assertEquals(429, e.getStatusCode());
+    assertEquals(Duration.ofSeconds(30), e.getRetryAfter());
+    assertTrue(e instanceof StreamApiException, "rate limit is a kind of API exception");
+  }
+
+  @Test
+  void rateLimit429_httpDateHeader_futureDelta() {
+    ZonedDateTime future = ZonedDateTime.now().plusSeconds(120);
+    String header = future.format(DateTimeFormatter.RFC_1123_DATE_TIME);
+    server.enqueue(
+        new MockResponse().setResponseCode(429).setHeader("Retry-After", header).setBody("{}"));
+
+    StreamRateLimitException e =
+        assertThrows(StreamRateLimitException.class, () -> request().execute());
+    assertNotNull(e.getRetryAfter());
+    long secs = e.getRetryAfter().getSeconds();
+    assertTrue(
+        secs > 60 && secs <= 121,
+        "future HTTP-date should produce a delta close to 120s, got " + secs);
+  }
+
+  @Test
+  void rateLimit429_httpDateHeader_pastIsClampedToZero() {
+    ZonedDateTime past = ZonedDateTime.now().minusSeconds(60);
+    String header = past.format(DateTimeFormatter.RFC_1123_DATE_TIME);
+    server.enqueue(
+        new MockResponse().setResponseCode(429).setHeader("Retry-After", header).setBody("{}"));
+
+    StreamRateLimitException e =
+        assertThrows(StreamRateLimitException.class, () -> request().execute());
+    assertEquals(Duration.ZERO, e.getRetryAfter(), "past HTTP-date must be clamped to zero");
+  }
+
+  @Test
+  void rateLimit429_missingHeader_retryAfterNull() {
+    server.enqueue(new MockResponse().setResponseCode(429).setBody("{}"));
+
+    StreamRateLimitException e =
+        assertThrows(StreamRateLimitException.class, () -> request().execute());
+    assertNull(e.getRetryAfter(), "missing Retry-After must be null");
+  }
+
+  @Test
+  void rateLimit429_unparseableHeader_retryAfterNull() {
+    server.enqueue(
+        new MockResponse().setResponseCode(429).setHeader("Retry-After", "soon").setBody("{}"));
+
+    StreamRateLimitException e =
+        assertThrows(StreamRateLimitException.class, () -> request().execute());
+    assertNull(e.getRetryAfter(), "unparseable Retry-After must be null (graceful)");
+  }
+
+  @Test
+  void transportError_serverDisconnect_yieldsTransportException() {
+    server.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START));
+
+    StreamTransportException e =
+        assertThrows(StreamTransportException.class, () -> request().execute());
+    assertNotNull(e.getCause(), "transport cause must be preserved");
+    assertNotNull(e.getErrorType(), "errorType must be set");
+  }
+
+  @Test
+  void transportError_timeout_yieldsTransportTimeoutException() {
+    server.enqueue(new MockResponse().setBody("{}").setBodyDelay(3, TimeUnit.SECONDS));
+
+    StreamTransportException e =
+        assertThrows(
+            StreamTransportException.class,
+            () -> request().callTimeout(Duration.ofMillis(100)).execute());
+    assertEquals(
+        StreamTransportException.TIMEOUT,
+        e.getErrorType(),
+        "call-timeout path must classify as timeout");
+  }
+
+  @Test
+  void newSubclassesAreCheckedAndCatchableAsStreamException() {
+    server.enqueue(
+        new MockResponse()
+            .setResponseCode(401)
+            .setBody("{\"code\":2,\"message\":\"unauth\",\"StatusCode\":401}"));
+
+    // The static type is StreamException — the dynamic type is the subclass. This is what
+    // back-compat depends on for `throws StreamException` callers.
+    StreamException e = assertThrows(StreamException.class, () -> request().execute());
+    assertTrue(e instanceof StreamApiException);
+    assertEquals(401, ((StreamApiException) e).getStatusCode());
+    // The base StreamException stays as a checked Exception — explicitly verified.
+    assertFalse(
+        e instanceof RuntimeException, "Java SDK keeps exceptions checked per CHA-2958 §9.3");
+  }
+}

--- a/src/test/java/io/getstream/StreamErrorHandlingTest.java
+++ b/src/test/java/io/getstream/StreamErrorHandlingTest.java
@@ -24,9 +24,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
- * Covers CHA-2958 error-handling spec for the request/response path: HTTP errors map to {@link
- * StreamApiException} / {@link StreamRateLimitException}, IO failures map to {@link
- * StreamTransportException}, and the existing {@link StreamException} base remains catchable.
+ * Covers the request/response error-handling path: HTTP errors map to {@link StreamApiException} /
+ * {@link StreamRateLimitException}, IO failures map to {@link StreamTransportException}, and the
+ * existing {@link StreamException} base remains catchable.
  */
 class StreamErrorHandlingTest {
   private MockWebServer server;
@@ -215,8 +215,6 @@ class StreamErrorHandlingTest {
     // The base StreamException stays as a checked Exception — explicitly verified.
     // Use Class#isInstance to bypass the JDK 21 unconditional-instanceof compile error
     // (StreamException is statically incompatible with RuntimeException).
-    assertFalse(
-        RuntimeException.class.isInstance(e),
-        "Java SDK keeps exceptions checked per CHA-2958 §9.3");
+    assertFalse(RuntimeException.class.isInstance(e), "Java SDK keeps exceptions checked");
   }
 }

--- a/src/test/java/io/getstream/StreamWaitForTaskTest.java
+++ b/src/test/java/io/getstream/StreamWaitForTaskTest.java
@@ -1,0 +1,143 @@
+package io.getstream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.getstream.exceptions.StreamException;
+import io.getstream.exceptions.StreamTaskException;
+import io.getstream.exceptions.StreamTransportException;
+import io.getstream.models.GetTaskResponse;
+import io.getstream.services.framework.StreamHTTPClient;
+import io.getstream.services.framework.StreamSDKClient;
+import java.io.IOException;
+import java.time.Duration;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** CHA-2958 §8: customer-facing task-wait helper on {@link StreamSDKClient}. */
+class StreamWaitForTaskTest {
+  private MockWebServer server;
+  private StreamSDKClient client;
+  private String prevUrl;
+  private String prevKey;
+  private String prevSecret;
+
+  @BeforeEach
+  void start() throws IOException {
+    server = new MockWebServer();
+    server.start();
+    prevUrl = System.getProperty(StreamHTTPClient.API_URL_PROP_NAME);
+    prevKey = System.getProperty(StreamHTTPClient.API_KEY_PROP_NAME);
+    prevSecret = System.getProperty(StreamHTTPClient.API_SECRET_PROP_NAME);
+    System.setProperty(
+        StreamHTTPClient.API_URL_PROP_NAME, server.url("/").toString());
+    System.setProperty(StreamHTTPClient.API_KEY_PROP_NAME, "apiKey");
+    System.setProperty(
+        StreamHTTPClient.API_SECRET_PROP_NAME, "012345678901234567890123456789ab");
+    client = new StreamSDKClient(System.getProperties());
+  }
+
+  @AfterEach
+  void stop() throws IOException {
+    server.shutdown();
+    restoreProperty(StreamHTTPClient.API_URL_PROP_NAME, prevUrl);
+    restoreProperty(StreamHTTPClient.API_KEY_PROP_NAME, prevKey);
+    restoreProperty(StreamHTTPClient.API_SECRET_PROP_NAME, prevSecret);
+  }
+
+  private static void restoreProperty(String key, String prev) {
+    if (prev == null) {
+      System.clearProperty(key);
+    } else {
+      System.setProperty(key, prev);
+    }
+  }
+
+  @Test
+  void completed_returnsTaskResponse() throws StreamException {
+    server.enqueue(
+        new MockResponse()
+            .setBody(
+                "{\"task_id\":\"t1\",\"status\":\"completed\",\"duration\":\"1ms\","
+                    + "\"result\":{\"k\":\"v\"}}"));
+
+    GetTaskResponse data =
+        client.waitForTask("t1", Duration.ZERO, Duration.ofSeconds(5));
+    assertEquals("completed", data.getStatus());
+    assertEquals("t1", data.getTaskID());
+    assertNotNull(data.getResult());
+    assertEquals("v", data.getResult().get("k"));
+  }
+
+  @Test
+  void failed_throwsStreamTaskException() {
+    server.enqueue(
+        new MockResponse()
+            .setBody(
+                "{\"task_id\":\"t2\",\"status\":\"failed\",\"duration\":\"1ms\","
+                    + "\"error\":{\"type\":\"OperationFailed\","
+                    + "\"description\":\"channel not found\","
+                    + "\"stacktrace\":\"goroutine 1...\","
+                    + "\"version\":\"v1.2.3\"}}"));
+
+    StreamTaskException e =
+        assertThrows(
+            StreamTaskException.class,
+            () -> client.waitForTask("t2", Duration.ZERO, Duration.ofSeconds(5)));
+    assertEquals("t2", e.getTaskId());
+    assertEquals("OperationFailed", e.getErrorType());
+    assertEquals("channel not found", e.getDescription());
+    assertEquals("goroutine 1...", e.getStackTraceText());
+    assertEquals("v1.2.3", e.getVersion());
+  }
+
+  @Test
+  void failed_missingErrorResult_stillThrowsWithEmptyFields() {
+    server.enqueue(
+        new MockResponse()
+            .setBody("{\"task_id\":\"t3\",\"status\":\"failed\",\"duration\":\"1ms\"}"));
+
+    StreamTaskException e =
+        assertThrows(
+            StreamTaskException.class,
+            () -> client.waitForTask("t3", Duration.ZERO, Duration.ofSeconds(5)));
+    assertEquals("t3", e.getTaskId());
+    assertEquals("", e.getErrorType());
+    assertEquals("", e.getDescription());
+    assertNull(e.getStackTraceText());
+    assertNull(e.getVersion());
+  }
+
+  @Test
+  void timeout_throwsStreamTransportExceptionTimeout() {
+    // Headroom: tight deadlines + slow CI shouldn't starve MockWebServer.
+    for (int i = 0; i < 20; i++) {
+      server.enqueue(
+          new MockResponse()
+              .setBody("{\"task_id\":\"t4\",\"status\":\"pending\",\"duration\":\"1ms\"}"));
+    }
+
+    StreamTransportException e =
+        assertThrows(
+            StreamTransportException.class,
+            () -> client.waitForTask("t4", Duration.ofMillis(50), Duration.ofMillis(200)));
+    assertEquals(StreamTransportException.TIMEOUT, e.getErrorType());
+    assertTrue(e.getMessage().contains("t4"), "message should reference taskId");
+  }
+
+  @Test
+  void negativeTimeout_rejected() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> client.waitForTask("any", Duration.ofSeconds(1), Duration.ofSeconds(-1)));
+  }
+
+  @Test
+  void negativePollInterval_rejected() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> client.waitForTask("any", Duration.ofSeconds(-1), Duration.ofSeconds(1)));
+  }
+}

--- a/src/test/java/io/getstream/StreamWaitForTaskTest.java
+++ b/src/test/java/io/getstream/StreamWaitForTaskTest.java
@@ -9,6 +9,7 @@ import io.getstream.models.GetTaskResponse;
 import io.getstream.services.framework.StreamHTTPClient;
 import io.getstream.services.framework.StreamSDKClient;
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.time.Duration;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -20,37 +21,25 @@ import org.junit.jupiter.api.Test;
 class StreamWaitForTaskTest {
   private MockWebServer server;
   private StreamSDKClient client;
-  private String prevUrl;
-  private String prevKey;
-  private String prevSecret;
 
   @BeforeEach
-  void start() throws IOException {
+  void start() throws Exception {
     server = new MockWebServer();
     server.start();
-    prevUrl = System.getProperty(StreamHTTPClient.API_URL_PROP_NAME);
-    prevKey = System.getProperty(StreamHTTPClient.API_KEY_PROP_NAME);
-    prevSecret = System.getProperty(StreamHTTPClient.API_SECRET_PROP_NAME);
-    System.setProperty(StreamHTTPClient.API_URL_PROP_NAME, server.url("/").toString());
-    System.setProperty(StreamHTTPClient.API_KEY_PROP_NAME, "apiKey");
-    System.setProperty(StreamHTTPClient.API_SECRET_PROP_NAME, "012345678901234567890123456789ab");
-    client = new StreamSDKClient(System.getProperties());
+    // Build via the credentials-only constructor (no env reading); force the
+    // baseUrl onto the mock server via reflection. CI sets STREAM_BASE_URL to
+    // the real API URL, so the env-reading Properties constructor would
+    // override any io.getstream.url system property the test could set.
+    StreamHTTPClient http = new StreamHTTPClient("apiKey", "012345678901234567890123456789ab");
+    Field baseUrl = StreamHTTPClient.class.getDeclaredField("baseUrl");
+    baseUrl.setAccessible(true);
+    baseUrl.set(http, server.url("/").toString());
+    client = new StreamSDKClient(http);
   }
 
   @AfterEach
   void stop() throws IOException {
     server.shutdown();
-    restoreProperty(StreamHTTPClient.API_URL_PROP_NAME, prevUrl);
-    restoreProperty(StreamHTTPClient.API_KEY_PROP_NAME, prevKey);
-    restoreProperty(StreamHTTPClient.API_SECRET_PROP_NAME, prevSecret);
-  }
-
-  private static void restoreProperty(String key, String prev) {
-    if (prev == null) {
-      System.clearProperty(key);
-    } else {
-      System.setProperty(key, prev);
-    }
   }
 
   @Test

--- a/src/test/java/io/getstream/StreamWaitForTaskTest.java
+++ b/src/test/java/io/getstream/StreamWaitForTaskTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-/** CHA-2958 §8: customer-facing task-wait helper on {@link StreamSDKClient}. */
+/** Customer-facing task-wait helper on {@link StreamSDKClient}. */
 class StreamWaitForTaskTest {
   private MockWebServer server;
   private StreamSDKClient client;

--- a/src/test/java/io/getstream/StreamWaitForTaskTest.java
+++ b/src/test/java/io/getstream/StreamWaitForTaskTest.java
@@ -31,11 +31,9 @@ class StreamWaitForTaskTest {
     prevUrl = System.getProperty(StreamHTTPClient.API_URL_PROP_NAME);
     prevKey = System.getProperty(StreamHTTPClient.API_KEY_PROP_NAME);
     prevSecret = System.getProperty(StreamHTTPClient.API_SECRET_PROP_NAME);
-    System.setProperty(
-        StreamHTTPClient.API_URL_PROP_NAME, server.url("/").toString());
+    System.setProperty(StreamHTTPClient.API_URL_PROP_NAME, server.url("/").toString());
     System.setProperty(StreamHTTPClient.API_KEY_PROP_NAME, "apiKey");
-    System.setProperty(
-        StreamHTTPClient.API_SECRET_PROP_NAME, "012345678901234567890123456789ab");
+    System.setProperty(StreamHTTPClient.API_SECRET_PROP_NAME, "012345678901234567890123456789ab");
     client = new StreamSDKClient(System.getProperties());
   }
 
@@ -63,8 +61,7 @@ class StreamWaitForTaskTest {
                 "{\"task_id\":\"t1\",\"status\":\"completed\",\"duration\":\"1ms\","
                     + "\"result\":{\"k\":\"v\"}}"));
 
-    GetTaskResponse data =
-        client.waitForTask("t1", Duration.ZERO, Duration.ofSeconds(5));
+    GetTaskResponse data = client.waitForTask("t1", Duration.ZERO, Duration.ofSeconds(5));
     assertEquals("completed", data.getStatus());
     assertEquals("t1", data.getTaskID());
     assertNotNull(data.getResult());


### PR DESCRIPTION
## Summary

- Four new CHECKED subclasses of `StreamException`:
  - `StreamApiException` — HTTP 4xx/5xx envelope (statusCode, code, exceptionFields, unrecoverable, rawResponseBody, moreInfo, details)
  - `StreamRateLimitException` — HTTP 429 + parsed `Retry-After` as `Duration`
  - `StreamTransportException` — IO failures with classified `errorType` enum, cause preserved
  - `StreamTaskException` — failed async task with `ErrorResult` fields
- `APIError` parser now surfaces the two previously-dropped fields: `unrecoverable` and `details`.
- `Retry-After` parser handles RFC 7231 §7.1.3 integer + IMF-fixdate HTTP-date; graceful on missing / unparseable.
- `client.waitForTask(taskId)` customer-facing helper (replaces the test-only `ChatTestBase.waitForTask`).

No breaking API changes — all new types are subclasses of the existing checked `StreamException`. `catch (StreamException)` still works; `throws StreamException` still compiles.

## Notable

- `StreamTaskException.getStackTraceText()` instead of `getStackTrace()` to avoid clobbering `Throwable.getStackTrace()`.
- 5 integration tests migrated from the deleted `ChatTestBase.waitForTask` to `client.waitForTask`. Old test helper silently swallowed `status="failed"`; the new helper throws `StreamTaskException`.

## Test plan

- [ ] `./gradlew build --info`
- [ ] `./gradlew test --no-daemon`
- [ ] `./gradlew spotlessCheck`