### PR TITLE
[CHA-2957] Java: sync generated client and wire structured logging

### DIFF
--- a/src/main/java/io/getstream/models/AppResponseFields.java
+++ b/src/main/java/io/getstream/models/AppResponseFields.java
@@ -72,6 +72,9 @@ public class AppResponseFields {
   @JsonProperty("moderation_enabled")
   private Boolean moderationEnabled;
 
+  @JsonProperty("moderation_flood_rules_enabled")
+  private Boolean moderationFloodRulesEnabled;
+
   @JsonProperty("moderation_llm_configurability_enabled")
   private Boolean moderationLlmConfigurabilityEnabled;
 
@@ -172,6 +175,10 @@ public class AppResponseFields {
   @Nullable
   @JsonProperty("before_message_send_hook_url")
   private String beforeMessageSendHookUrl;
+
+  @Nullable
+  @JsonProperty("chat_primary_use_case")
+  private String chatPrimaryUseCase;
 
   @Nullable
   @JsonProperty("moderation_onboarding_complete")

--- a/src/main/java/io/getstream/models/BanInfoResponse.java
+++ b/src/main/java/io/getstream/models/BanInfoResponse.java
@@ -27,6 +27,10 @@ public class BanInfoResponse {
   private Date createdAt;
 
   @Nullable
+  @JsonProperty("channel_cid")
+  private String channelCid;
+
+  @Nullable
   @JsonProperty("expires")
   private Date expires;
 
@@ -37,6 +41,10 @@ public class BanInfoResponse {
   @Nullable
   @JsonProperty("shadow")
   private Boolean shadow;
+
+  @Nullable
+  @JsonProperty("channel")
+  private ChannelMetadata channel;
 
   @Nullable
   @JsonProperty("created_by")

--- a/src/main/java/io/getstream/models/BlockListResponse.java
+++ b/src/main/java/io/getstream/models/BlockListResponse.java
@@ -54,6 +54,10 @@ public class BlockListResponse {
   private String id;
 
   @Nullable
+  @JsonProperty("owner_user_id")
+  private String ownerUserID;
+
+  @Nullable
   @JsonProperty("team")
   private String team;
 

--- a/src/main/java/io/getstream/models/CallSettingsRequest.java
+++ b/src/main/java/io/getstream/models/CallSettingsRequest.java
@@ -34,6 +34,10 @@ public class CallSettingsRequest {
   private BroadcastSettingsRequest broadcasting;
 
   @Nullable
+  @JsonProperty("encryption")
+  private EncryptionSettingsRequest encryption;
+
+  @Nullable
   @JsonProperty("frame_recording")
   private FrameRecordingSettingsRequest frameRecording;
 

--- a/src/main/java/io/getstream/models/CallSettingsResponse.java
+++ b/src/main/java/io/getstream/models/CallSettingsResponse.java
@@ -30,6 +30,9 @@ public class CallSettingsResponse {
   @JsonProperty("broadcasting")
   private BroadcastSettingsResponse broadcasting;
 
+  @JsonProperty("encryption")
+  private EncryptionSettingsResponse encryption;
+
   @JsonProperty("frame_recording")
   private FrameRecordingSettingsResponse frameRecording;
 

--- a/src/main/java/io/getstream/models/ChannelMemberPartialResponse.java
+++ b/src/main/java/io/getstream/models/ChannelMemberPartialResponse.java
@@ -12,25 +12,17 @@
  */
 package io.getstream.models;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import io.getstream.annotations.Query;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
-/** Get comment Get a comment by ID */
 @lombok.Data
 @lombok.Builder
 @lombok.NoArgsConstructor
 @lombok.AllArgsConstructor
-public class GetCommentRequest {
+public class ChannelMemberPartialResponse {
 
-  @Query("user_id")
-  @JsonIgnore
-  private String UserID;
+  @JsonProperty("channel_role")
+  private String channelRole;
 
-  @Query("language")
-  @JsonIgnore
-  private String Language;
-
-  @Query("translate_text")
-  @JsonIgnore
-  private Boolean TranslateText;
+  @JsonProperty("notifications_muted")
+  private Boolean notificationsMuted;
 }

--- a/src/main/java/io/getstream/models/ChannelMetadata.java
+++ b/src/main/java/io/getstream/models/ChannelMetadata.java
@@ -13,23 +13,45 @@
 package io.getstream.models;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.util.List;
+import java.util.Date;
+import java.util.Map;
 import org.jetbrains.annotations.Nullable;
 
-/** Basic response information */
 @lombok.Data
 @lombok.Builder
 @lombok.NoArgsConstructor
 @lombok.AllArgsConstructor
-public class ListBlockListResponse {
+public class ChannelMetadata {
 
-  @JsonProperty("duration")
-  private String duration;
+  @JsonProperty("cid")
+  private String cid;
 
-  @JsonProperty("blocklists")
-  private List<BlockListResponse> blocklists;
+  @JsonProperty("id")
+  private String id;
+
+  @JsonProperty("type")
+  private String type;
+
+  @JsonProperty("custom")
+  private Map<String, Object> custom;
 
   @Nullable
-  @JsonProperty("next_cursor")
-  private String nextCursor;
+  @JsonProperty("last_message_at")
+  private Date lastMessageAt;
+
+  @Nullable
+  @JsonProperty("member_count")
+  private Integer memberCount;
+
+  @Nullable
+  @JsonProperty("message_count")
+  private Integer messageCount;
+
+  @Nullable
+  @JsonProperty("push_level")
+  private String pushLevel;
+
+  @Nullable
+  @JsonProperty("team")
+  private String team;
 }

--- a/src/main/java/io/getstream/models/ChatMessageResponse.java
+++ b/src/main/java/io/getstream/models/ChatMessageResponse.java
@@ -167,7 +167,7 @@ public class ChatMessageResponse {
 
   @Nullable
   @JsonProperty("member")
-  private ChannelMemberResponse member;
+  private ChannelMemberPartialResponse member;
 
   @Nullable
   @JsonProperty("moderation")

--- a/src/main/java/io/getstream/models/ClientEvent.java
+++ b/src/main/java/io/getstream/models/ClientEvent.java
@@ -64,6 +64,10 @@ public class ClientEvent {
   private String joinAttemptID;
 
   @Nullable
+  @JsonProperty("join_reason")
+  private String joinReason;
+
+  @Nullable
   @JsonProperty("microphone_permission_status")
   private String microphonePermissionStatus;
 

--- a/src/main/java/io/getstream/models/EncryptionSettingsRequest.java
+++ b/src/main/java/io/getstream/models/EncryptionSettingsRequest.java
@@ -12,25 +12,16 @@
  */
 package io.getstream.models;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import io.getstream.annotations.Query;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.jetbrains.annotations.Nullable;
 
-/** Get comment Get a comment by ID */
 @lombok.Data
 @lombok.Builder
 @lombok.NoArgsConstructor
 @lombok.AllArgsConstructor
-public class GetCommentRequest {
+public class EncryptionSettingsRequest {
 
-  @Query("user_id")
-  @JsonIgnore
-  private String UserID;
-
-  @Query("language")
-  @JsonIgnore
-  private String Language;
-
-  @Query("translate_text")
-  @JsonIgnore
-  private Boolean TranslateText;
+  @Nullable
+  @JsonProperty("enabled")
+  private Boolean enabled;
 }

--- a/src/main/java/io/getstream/models/EncryptionSettingsResponse.java
+++ b/src/main/java/io/getstream/models/EncryptionSettingsResponse.java
@@ -12,25 +12,15 @@
  */
 package io.getstream.models;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import io.getstream.annotations.Query;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
-/** Get comment Get a comment by ID */
+/** EncryptionSettings is the payload for end-to-end encryption settings */
 @lombok.Data
 @lombok.Builder
 @lombok.NoArgsConstructor
 @lombok.AllArgsConstructor
-public class GetCommentRequest {
+public class EncryptionSettingsResponse {
 
-  @Query("user_id")
-  @JsonIgnore
-  private String UserID;
-
-  @Query("language")
-  @JsonIgnore
-  private String Language;
-
-  @Query("translate_text")
-  @JsonIgnore
-  private Boolean TranslateText;
+  @JsonProperty("enabled")
+  private Boolean enabled;
 }

--- a/src/main/java/io/getstream/models/FloodIdenticalRuleParameters.java
+++ b/src/main/java/io/getstream/models/FloodIdenticalRuleParameters.java
@@ -12,25 +12,20 @@
  */
 package io.getstream.models;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import io.getstream.annotations.Query;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.jetbrains.annotations.Nullable;
 
-/** Get comment Get a comment by ID */
 @lombok.Data
 @lombok.Builder
 @lombok.NoArgsConstructor
 @lombok.AllArgsConstructor
-public class GetCommentRequest {
+public class FloodIdenticalRuleParameters {
 
-  @Query("user_id")
-  @JsonIgnore
-  private String UserID;
+  @Nullable
+  @JsonProperty("threshold")
+  private Integer threshold;
 
-  @Query("language")
-  @JsonIgnore
-  private String Language;
-
-  @Query("translate_text")
-  @JsonIgnore
-  private Boolean TranslateText;
+  @Nullable
+  @JsonProperty("time_window")
+  private String timeWindow;
 }

--- a/src/main/java/io/getstream/models/FloodSimilarRuleParameters.java
+++ b/src/main/java/io/getstream/models/FloodSimilarRuleParameters.java
@@ -12,25 +12,24 @@
  */
 package io.getstream.models;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import io.getstream.annotations.Query;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.jetbrains.annotations.Nullable;
 
-/** Get comment Get a comment by ID */
 @lombok.Data
 @lombok.Builder
 @lombok.NoArgsConstructor
 @lombok.AllArgsConstructor
-public class GetCommentRequest {
+public class FloodSimilarRuleParameters {
 
-  @Query("user_id")
-  @JsonIgnore
-  private String UserID;
+  @Nullable
+  @JsonProperty("similarity_distance")
+  private Integer similarityDistance;
 
-  @Query("language")
-  @JsonIgnore
-  private String Language;
+  @Nullable
+  @JsonProperty("threshold")
+  private Integer threshold;
 
-  @Query("translate_text")
-  @JsonIgnore
-  private Boolean TranslateText;
+  @Nullable
+  @JsonProperty("time_window")
+  private String timeWindow;
 }

--- a/src/main/java/io/getstream/models/GetActivityRequest.java
+++ b/src/main/java/io/getstream/models/GetActivityRequest.java
@@ -22,14 +22,6 @@ import io.getstream.annotations.Query;
 @lombok.AllArgsConstructor
 public class GetActivityRequest {
 
-  @Query("language")
-  @JsonIgnore
-  private String Language;
-
-  @Query("translate_text")
-  @JsonIgnore
-  private Boolean TranslateText;
-
   @Query("comment_sort")
   @JsonIgnore
   private String CommentSort;
@@ -41,4 +33,12 @@ public class GetActivityRequest {
   @Query("user_id")
   @JsonIgnore
   private String UserID;
+
+  @Query("language")
+  @JsonIgnore
+  private String Language;
+
+  @Query("translate_text")
+  @JsonIgnore
+  private Boolean TranslateText;
 }

--- a/src/main/java/io/getstream/models/IPContentCountRuleParameters.java
+++ b/src/main/java/io/getstream/models/IPContentCountRuleParameters.java
@@ -12,25 +12,20 @@
  */
 package io.getstream.models;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import io.getstream.annotations.Query;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.jetbrains.annotations.Nullable;
 
-/** Get comment Get a comment by ID */
 @lombok.Data
 @lombok.Builder
 @lombok.NoArgsConstructor
 @lombok.AllArgsConstructor
-public class GetCommentRequest {
+public class IPContentCountRuleParameters {
 
-  @Query("user_id")
-  @JsonIgnore
-  private String UserID;
+  @Nullable
+  @JsonProperty("threshold")
+  private Integer threshold;
 
-  @Query("language")
-  @JsonIgnore
-  private String Language;
-
-  @Query("translate_text")
-  @JsonIgnore
-  private Boolean TranslateText;
+  @Nullable
+  @JsonProperty("time_window")
+  private String timeWindow;
 }

--- a/src/main/java/io/getstream/models/IPFlagCountRuleParameters.java
+++ b/src/main/java/io/getstream/models/IPFlagCountRuleParameters.java
@@ -12,25 +12,29 @@
  */
 package io.getstream.models;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import io.getstream.annotations.Query;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import org.jetbrains.annotations.Nullable;
 
-/** Get comment Get a comment by ID */
 @lombok.Data
 @lombok.Builder
 @lombok.NoArgsConstructor
 @lombok.AllArgsConstructor
-public class GetCommentRequest {
+public class IPFlagCountRuleParameters {
 
-  @Query("user_id")
-  @JsonIgnore
-  private String UserID;
+  @Nullable
+  @JsonProperty("severity")
+  private String severity;
 
-  @Query("language")
-  @JsonIgnore
-  private String Language;
+  @Nullable
+  @JsonProperty("threshold")
+  private Integer threshold;
 
-  @Query("translate_text")
-  @JsonIgnore
-  private Boolean TranslateText;
+  @Nullable
+  @JsonProperty("time_window")
+  private String timeWindow;
+
+  @Nullable
+  @JsonProperty("harm_labels")
+  private List<String> harmLabels;
 }

--- a/src/main/java/io/getstream/models/ImportBlockListRequest.java
+++ b/src/main/java/io/getstream/models/ImportBlockListRequest.java
@@ -16,20 +16,23 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 import org.jetbrains.annotations.Nullable;
 
-/** Basic response information */
+/**
+ * Import block list items Enqueues an asynchronous bulk import of items into an existing blocklist.
+ * Returns a task ID that can be polled via GET /tasks/{id} to observe progress. AddItems is
+ * idempotent: items already present are skipped without error. For lists exceeding the HTTP
+ * request-body cap, issue repeated import calls each carrying a bounded slice of items — the task
+ * result accumulates correctly.
+ */
 @lombok.Data
 @lombok.Builder
 @lombok.NoArgsConstructor
 @lombok.AllArgsConstructor
-public class ListBlockListResponse {
+public class ImportBlockListRequest {
 
-  @JsonProperty("duration")
-  private String duration;
-
-  @JsonProperty("blocklists")
-  private List<BlockListResponse> blocklists;
+  @JsonProperty("items")
+  private List<String> items;
 
   @Nullable
-  @JsonProperty("next_cursor")
-  private String nextCursor;
+  @JsonProperty("chunk_size")
+  private Integer chunkSize;
 }

--- a/src/main/java/io/getstream/models/ImportBlockListResponse.java
+++ b/src/main/java/io/getstream/models/ImportBlockListResponse.java
@@ -12,25 +12,18 @@
  */
 package io.getstream.models;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import io.getstream.annotations.Query;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
-/** Get comment Get a comment by ID */
+/** Basic response information */
 @lombok.Data
 @lombok.Builder
 @lombok.NoArgsConstructor
 @lombok.AllArgsConstructor
-public class GetCommentRequest {
+public class ImportBlockListResponse {
 
-  @Query("user_id")
-  @JsonIgnore
-  private String UserID;
+  @JsonProperty("duration")
+  private String duration;
 
-  @Query("language")
-  @JsonIgnore
-  private String Language;
-
-  @Query("translate_text")
-  @JsonIgnore
-  private Boolean TranslateText;
+  @JsonProperty("task_id")
+  private String taskID;
 }

--- a/src/main/java/io/getstream/models/ImportV2TaskSettings.java
+++ b/src/main/java/io/getstream/models/ImportV2TaskSettings.java
@@ -38,10 +38,6 @@ public class ImportV2TaskSettings {
   private Boolean skipReferencesCheck;
 
   @Nullable
-  @JsonProperty("source")
-  private String source;
-
-  @Nullable
   @JsonProperty("use_import_time_as_op_time")
   private Boolean useImportTimeAsOpTime;
 

--- a/src/main/java/io/getstream/models/ListBlockListsRequest.java
+++ b/src/main/java/io/getstream/models/ListBlockListsRequest.java
@@ -25,4 +25,12 @@ public class ListBlockListsRequest {
   @Query("team")
   @JsonIgnore
   private String Team;
+
+  @Query("cursor")
+  @JsonIgnore
+  private String Cursor;
+
+  @Query("limit")
+  @JsonIgnore
+  private Integer Limit;
 }

--- a/src/main/java/io/getstream/models/MessageResponse.java
+++ b/src/main/java/io/getstream/models/MessageResponse.java
@@ -168,7 +168,7 @@ public class MessageResponse {
 
   @Nullable
   @JsonProperty("member")
-  private ChannelMemberResponse member;
+  private ChannelMemberPartialResponse member;
 
   @Nullable
   @JsonProperty("moderation")

--- a/src/main/java/io/getstream/models/MessageWithChannelResponse.java
+++ b/src/main/java/io/getstream/models/MessageWithChannelResponse.java
@@ -171,7 +171,7 @@ public class MessageWithChannelResponse {
 
   @Nullable
   @JsonProperty("member")
-  private ChannelMemberResponse member;
+  private ChannelMemberPartialResponse member;
 
   @Nullable
   @JsonProperty("moderation")

--- a/src/main/java/io/getstream/models/RuleBuilderCondition.java
+++ b/src/main/java/io/getstream/models/RuleBuilderCondition.java
@@ -66,12 +66,28 @@ public class RuleBuilderCondition {
   private FlagCountRuleParameters contentFlagCountRuleParams;
 
   @Nullable
+  @JsonProperty("flood_identical_params")
+  private FloodIdenticalRuleParameters floodIdenticalParams;
+
+  @Nullable
+  @JsonProperty("flood_similar_params")
+  private FloodSimilarRuleParameters floodSimilarParams;
+
+  @Nullable
   @JsonProperty("image_content_params")
   private ImageContentParameters imageContentParams;
 
   @Nullable
   @JsonProperty("image_rule_params")
   private ImageRuleParameters imageRuleParams;
+
+  @Nullable
+  @JsonProperty("ip_content_count_rule_params")
+  private IPContentCountRuleParameters ipContentCountRuleParams;
+
+  @Nullable
+  @JsonProperty("ip_flag_count_rule_params")
+  private IPFlagCountRuleParameters ipFlagCountRuleParams;
 
   @Nullable
   @JsonProperty("keyframe_ocr_rule_params")

--- a/src/main/java/io/getstream/models/SearchResultMessage.java
+++ b/src/main/java/io/getstream/models/SearchResultMessage.java
@@ -171,7 +171,7 @@ public class SearchResultMessage {
 
   @Nullable
   @JsonProperty("member")
-  private ChannelMemberResponse member;
+  private ChannelMemberPartialResponse member;
 
   @Nullable
   @JsonProperty("moderation")

--- a/src/main/java/io/getstream/models/UpdateAppRequest.java
+++ b/src/main/java/io/getstream/models/UpdateAppRequest.java
@@ -50,6 +50,10 @@ public class UpdateAppRequest {
   private Boolean channelHideMembersOnly;
 
   @Nullable
+  @JsonProperty("chat_primary_use_case")
+  private String chatPrimaryUseCase;
+
+  @Nullable
   @JsonProperty("custom_action_handler_url")
   private String customActionHandlerUrl;
 

--- a/src/main/java/io/getstream/services/ChatImpl.java
+++ b/src/main/java/io/getstream/services/ChatImpl.java
@@ -32,9 +32,7 @@ public class ChatImpl {
       throws StreamException {
 
     return new StreamRequest<CreateCampaignResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/chat/campaigns",
         request,
@@ -47,9 +45,7 @@ public class ChatImpl {
       throws StreamException {
 
     return new StreamRequest<QueryCampaignsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/chat/campaigns/query",
         request,
@@ -68,9 +64,7 @@ public class ChatImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<DeleteCampaignResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "DELETE",
         "/api/v2/chat/campaigns/{id}",
         request,
@@ -90,9 +84,7 @@ public class ChatImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<GetCampaignResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/chat/campaigns/{id}",
         request,
@@ -111,9 +103,7 @@ public class ChatImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<CampaignResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "PUT",
         "/api/v2/chat/campaigns/{id}",
         request,
@@ -127,9 +117,7 @@ public class ChatImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<StartCampaignResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/chat/campaigns/{id}/start",
         request,
@@ -149,9 +137,7 @@ public class ChatImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<CampaignResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/chat/campaigns/{id}/stop",
         request,
@@ -169,9 +155,7 @@ public class ChatImpl {
       throws StreamException {
 
     return new StreamRequest<QueryChannelsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/chat/channels",
         request,
@@ -189,9 +173,7 @@ public class ChatImpl {
       ChannelBatchUpdateRequest request) throws StreamException {
 
     return new StreamRequest<ChannelBatchUpdateResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "PUT",
         "/api/v2/chat/channels/batch",
         request,
@@ -204,9 +186,7 @@ public class ChatImpl {
       throws StreamException {
 
     return new StreamRequest<DeleteChannelsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/chat/channels/delete",
         request,
@@ -219,9 +199,7 @@ public class ChatImpl {
       throws StreamException {
 
     return new StreamRequest<MarkDeliveredResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/chat/channels/delivered",
         request,
@@ -239,9 +217,7 @@ public class ChatImpl {
       GroupedQueryChannelsRequest request) throws StreamException {
 
     return new StreamRequest<GroupedQueryChannelsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/chat/channels/grouped",
         request,
@@ -259,9 +235,7 @@ public class ChatImpl {
       throws StreamException {
 
     return new StreamRequest<MarkReadResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/chat/channels/read",
         request,
@@ -280,9 +254,7 @@ public class ChatImpl {
     var pathParams = Map.of("type", type);
 
     return new StreamRequest<ChannelStateResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/chat/channels/{type}/query",
         request,
@@ -306,9 +278,7 @@ public class ChatImpl {
             "id", id);
 
     return new StreamRequest<DeleteChannelResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "DELETE",
         "/api/v2/chat/channels/{type}/{id}",
         request,
@@ -331,9 +301,7 @@ public class ChatImpl {
             "id", id);
 
     return new StreamRequest<ChannelStateResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/chat/channels/{type}/{id}",
         request,
@@ -357,9 +325,7 @@ public class ChatImpl {
             "id", id);
 
     return new StreamRequest<UpdateChannelPartialResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "PATCH",
         "/api/v2/chat/channels/{type}/{id}",
         request,
@@ -383,9 +349,7 @@ public class ChatImpl {
             "id", id);
 
     return new StreamRequest<UpdateChannelResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/chat/channels/{type}/{id}",
         request,
@@ -408,9 +372,7 @@ public class ChatImpl {
             "id", id);
 
     return new StreamRequest<Response>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "DELETE",
         "/api/v2/chat/channels/{type}/{id}/draft",
         request,
@@ -433,9 +395,7 @@ public class ChatImpl {
             "id", id);
 
     return new StreamRequest<GetDraftResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/chat/channels/{type}/{id}/draft",
         request,
@@ -458,9 +418,7 @@ public class ChatImpl {
             "id", id);
 
     return new StreamRequest<EventResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/chat/channels/{type}/{id}/event",
         request,
@@ -478,9 +436,7 @@ public class ChatImpl {
             "id", id);
 
     return new StreamRequest<Response>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "DELETE",
         "/api/v2/chat/channels/{type}/{id}/file",
         request,
@@ -504,9 +460,7 @@ public class ChatImpl {
             "id", id);
 
     return new StreamRequest<UploadChannelFileResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/chat/channels/{type}/{id}/file",
         request,
@@ -529,9 +483,7 @@ public class ChatImpl {
             "id", id);
 
     return new StreamRequest<HideChannelResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/chat/channels/{type}/{id}/hide",
         request,
@@ -555,9 +507,7 @@ public class ChatImpl {
             "id", id);
 
     return new StreamRequest<Response>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "DELETE",
         "/api/v2/chat/channels/{type}/{id}/image",
         request,
@@ -581,9 +531,7 @@ public class ChatImpl {
             "id", id);
 
     return new StreamRequest<UploadChannelResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/chat/channels/{type}/{id}/image",
         request,
@@ -607,9 +555,7 @@ public class ChatImpl {
             "id", id);
 
     return new StreamRequest<UpdateMemberPartialResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "PATCH",
         "/api/v2/chat/channels/{type}/{id}/member",
         request,
@@ -632,9 +578,7 @@ public class ChatImpl {
             "id", id);
 
     return new StreamRequest<SendMessageResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/chat/channels/{type}/{id}/message",
         request,
@@ -652,9 +596,7 @@ public class ChatImpl {
             "id", id);
 
     return new StreamRequest<GetManyMessagesResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/chat/channels/{type}/{id}/messages",
         request,
@@ -672,9 +614,7 @@ public class ChatImpl {
             "id", id);
 
     return new StreamRequest<ChannelStateResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/chat/channels/{type}/{id}/query",
         request,
@@ -697,9 +637,7 @@ public class ChatImpl {
             "id", id);
 
     return new StreamRequest<MarkReadResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/chat/channels/{type}/{id}/read",
         request,
@@ -722,9 +660,7 @@ public class ChatImpl {
             "id", id);
 
     return new StreamRequest<ShowChannelResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/chat/channels/{type}/{id}/show",
         request,
@@ -748,9 +684,7 @@ public class ChatImpl {
             "id", id);
 
     return new StreamRequest<TruncateChannelResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/chat/channels/{type}/{id}/truncate",
         request,
@@ -773,9 +707,7 @@ public class ChatImpl {
             "id", id);
 
     return new StreamRequest<Response>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/chat/channels/{type}/{id}/unread",
         request,
@@ -794,9 +726,7 @@ public class ChatImpl {
       throws StreamException {
 
     return new StreamRequest<ListChannelTypesResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/chat/channeltypes",
         request,
@@ -814,9 +744,7 @@ public class ChatImpl {
       CreateChannelTypeRequest request) throws StreamException {
 
     return new StreamRequest<CreateChannelTypeResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/chat/channeltypes",
         request,
@@ -830,9 +758,7 @@ public class ChatImpl {
     var pathParams = Map.of("name", name);
 
     return new StreamRequest<Response>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "DELETE",
         "/api/v2/chat/channeltypes/{name}",
         request,
@@ -851,9 +777,7 @@ public class ChatImpl {
     var pathParams = Map.of("name", name);
 
     return new StreamRequest<GetChannelTypeResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/chat/channeltypes/{name}",
         request,
@@ -873,9 +797,7 @@ public class ChatImpl {
     var pathParams = Map.of("name", name);
 
     return new StreamRequest<UpdateChannelTypeResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "PUT",
         "/api/v2/chat/channeltypes/{name}",
         request,
@@ -888,9 +810,7 @@ public class ChatImpl {
       throws StreamException {
 
     return new StreamRequest<ListCommandsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/chat/commands",
         request,
@@ -908,9 +828,7 @@ public class ChatImpl {
       throws StreamException {
 
     return new StreamRequest<CreateCommandResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/chat/commands",
         request,
@@ -924,9 +842,7 @@ public class ChatImpl {
     var pathParams = Map.of("name", name);
 
     return new StreamRequest<DeleteCommandResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "DELETE",
         "/api/v2/chat/commands/{name}",
         request,
@@ -946,9 +862,7 @@ public class ChatImpl {
     var pathParams = Map.of("name", name);
 
     return new StreamRequest<GetCommandResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/chat/commands/{name}",
         request,
@@ -967,9 +881,7 @@ public class ChatImpl {
     var pathParams = Map.of("name", name);
 
     return new StreamRequest<UpdateCommandResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "PUT",
         "/api/v2/chat/commands/{name}",
         request,
@@ -982,9 +894,7 @@ public class ChatImpl {
       throws StreamException {
 
     return new StreamRequest<QueryDraftsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/chat/drafts/query",
         request,
@@ -1002,9 +912,7 @@ public class ChatImpl {
       throws StreamException {
 
     return new StreamRequest<ExportChannelsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/chat/export_channels",
         request,
@@ -1017,9 +925,7 @@ public class ChatImpl {
       throws StreamException {
 
     return new StreamRequest<MembersResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/chat/members",
         request,
@@ -1037,9 +943,7 @@ public class ChatImpl {
       QueryMessageHistoryRequest request) throws StreamException {
 
     return new StreamRequest<QueryMessageHistoryResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/chat/messages/history",
         request,
@@ -1053,9 +957,7 @@ public class ChatImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<DeleteMessageResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "DELETE",
         "/api/v2/chat/messages/{id}",
         request,
@@ -1075,9 +977,7 @@ public class ChatImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<GetMessageResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/chat/messages/{id}",
         request,
@@ -1096,9 +996,7 @@ public class ChatImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<UpdateMessageResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/chat/messages/{id}",
         request,
@@ -1112,9 +1010,7 @@ public class ChatImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<UpdateMessagePartialResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "PUT",
         "/api/v2/chat/messages/{id}",
         request,
@@ -1134,9 +1030,7 @@ public class ChatImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<MessageActionResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/chat/messages/{id}/action",
         request,
@@ -1150,9 +1044,7 @@ public class ChatImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<MessageActionResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/chat/messages/{id}/commit",
         request,
@@ -1172,9 +1064,7 @@ public class ChatImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<UpdateMessagePartialResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "PATCH",
         "/api/v2/chat/messages/{id}/ephemeral",
         request,
@@ -1194,9 +1084,7 @@ public class ChatImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<SendReactionResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/chat/messages/{id}/reaction",
         request,
@@ -1214,9 +1102,7 @@ public class ChatImpl {
             "type", type);
 
     return new StreamRequest<DeleteReactionResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "DELETE",
         "/api/v2/chat/messages/{id}/reaction/{type}",
         request,
@@ -1236,9 +1122,7 @@ public class ChatImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<GetReactionsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/chat/messages/{id}/reactions",
         request,
@@ -1258,9 +1142,7 @@ public class ChatImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<QueryReactionsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/chat/messages/{id}/reactions",
         request,
@@ -1280,9 +1162,7 @@ public class ChatImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<MessageActionResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/chat/messages/{id}/translate",
         request,
@@ -1296,9 +1176,7 @@ public class ChatImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<UndeleteMessageResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/chat/messages/{id}/undelete",
         request,
@@ -1316,9 +1194,7 @@ public class ChatImpl {
             "poll_id", pollID);
 
     return new StreamRequest<PollVoteResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/chat/messages/{message_id}/polls/{poll_id}/vote",
         request,
@@ -1346,9 +1222,7 @@ public class ChatImpl {
             "vote_id", voteID);
 
     return new StreamRequest<PollVoteResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "DELETE",
         "/api/v2/chat/messages/{message_id}/polls/{poll_id}/vote/{vote_id}",
         request,
@@ -1369,9 +1243,7 @@ public class ChatImpl {
     var pathParams = Map.of("message_id", messageID);
 
     return new StreamRequest<DeleteReminderResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "DELETE",
         "/api/v2/chat/messages/{message_id}/reminders",
         request,
@@ -1391,9 +1263,7 @@ public class ChatImpl {
     var pathParams = Map.of("message_id", messageID);
 
     return new StreamRequest<UpdateReminderResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "PATCH",
         "/api/v2/chat/messages/{message_id}/reminders",
         request,
@@ -1413,9 +1283,7 @@ public class ChatImpl {
     var pathParams = Map.of("message_id", messageID);
 
     return new StreamRequest<ReminderResponseData>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/chat/messages/{message_id}/reminders",
         request,
@@ -1435,9 +1303,7 @@ public class ChatImpl {
     var pathParams = Map.of("parent_id", parentID);
 
     return new StreamRequest<GetRepliesResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/chat/messages/{parent_id}/replies",
         request,
@@ -1456,9 +1322,7 @@ public class ChatImpl {
       QueryMessageFlagsRequest request) throws StreamException {
 
     return new StreamRequest<QueryMessageFlagsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/chat/moderation/flags/message",
         request,
@@ -1476,9 +1340,7 @@ public class ChatImpl {
       throws StreamException {
 
     return new StreamRequest<MuteChannelResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/chat/moderation/mute/channel",
         request,
@@ -1496,9 +1358,7 @@ public class ChatImpl {
       throws StreamException {
 
     return new StreamRequest<UnmuteResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/chat/moderation/unmute/channel",
         request,
@@ -1516,9 +1376,7 @@ public class ChatImpl {
       throws StreamException {
 
     return new StreamRequest<QueryBannedUsersResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/chat/query_banned_users",
         request,
@@ -1536,9 +1394,7 @@ public class ChatImpl {
       QueryFutureChannelBansRequest request) throws StreamException {
 
     return new StreamRequest<QueryFutureChannelBansResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/chat/query_future_channel_bans",
         request,
@@ -1557,9 +1413,7 @@ public class ChatImpl {
       throws StreamException {
 
     return new StreamRequest<QueryRemindersResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/chat/reminders/query",
         request,
@@ -1577,9 +1431,7 @@ public class ChatImpl {
       GetRetentionPolicyRequest request) throws StreamException {
 
     return new StreamRequest<GetRetentionPolicyResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/chat/retention_policy",
         request,
@@ -1597,9 +1449,7 @@ public class ChatImpl {
       SetRetentionPolicyRequest request) throws StreamException {
 
     return new StreamRequest<SetRetentionPolicyResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/chat/retention_policy",
         request,
@@ -1612,9 +1462,7 @@ public class ChatImpl {
       DeleteRetentionPolicyRequest request) throws StreamException {
 
     return new StreamRequest<DeleteRetentionPolicyResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/chat/retention_policy/delete",
         request,
@@ -1627,9 +1475,7 @@ public class ChatImpl {
       GetRetentionPolicyRunsRequest request) throws StreamException {
 
     return new StreamRequest<GetRetentionPolicyRunsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/chat/retention_policy/runs",
         request,
@@ -1647,9 +1493,7 @@ public class ChatImpl {
   public StreamRequest<SearchResponse> search(SearchRequest request) throws StreamException {
 
     return new StreamRequest<SearchResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/chat/search",
         request,
@@ -1667,9 +1511,7 @@ public class ChatImpl {
       throws StreamException {
 
     return new StreamRequest<CreateSegmentResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/chat/segments",
         request,
@@ -1682,9 +1524,7 @@ public class ChatImpl {
       throws StreamException {
 
     return new StreamRequest<QuerySegmentsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/chat/segments/query",
         request,
@@ -1698,9 +1538,7 @@ public class ChatImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<Response>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "DELETE",
         "/api/v2/chat/segments/{id}",
         request,
@@ -1719,9 +1557,7 @@ public class ChatImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<GetSegmentResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/chat/segments/{id}",
         request,
@@ -1740,9 +1576,7 @@ public class ChatImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<UpdateSegmentResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "PUT",
         "/api/v2/chat/segments/{id}",
         request,
@@ -1762,9 +1596,7 @@ public class ChatImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<Response>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/chat/segments/{id}/addtargets",
         request,
@@ -1778,9 +1610,7 @@ public class ChatImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<Response>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/chat/segments/{id}/deletetargets",
         request,
@@ -1798,9 +1628,7 @@ public class ChatImpl {
             "target_id", targetID);
 
     return new StreamRequest<Response>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/chat/segments/{id}/target/{target_id}",
         request,
@@ -1820,9 +1648,7 @@ public class ChatImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<QuerySegmentTargetsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/chat/segments/{id}/targets/query",
         request,
@@ -1841,9 +1667,7 @@ public class ChatImpl {
       QueryTeamUsageStatsRequest request) throws StreamException {
 
     return new StreamRequest<QueryTeamUsageStatsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/chat/stats/team_usage",
         request,
@@ -1861,9 +1685,7 @@ public class ChatImpl {
       throws StreamException {
 
     return new StreamRequest<QueryThreadsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/chat/threads",
         request,
@@ -1882,9 +1704,7 @@ public class ChatImpl {
     var pathParams = Map.of("message_id", messageID);
 
     return new StreamRequest<GetThreadResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/chat/threads/{message_id}",
         request,
@@ -1904,9 +1724,7 @@ public class ChatImpl {
     var pathParams = Map.of("message_id", messageID);
 
     return new StreamRequest<UpdateThreadPartialResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "PATCH",
         "/api/v2/chat/threads/{message_id}",
         request,
@@ -1925,9 +1743,7 @@ public class ChatImpl {
       throws StreamException {
 
     return new StreamRequest<WrappedUnreadCountsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/chat/unread",
         request,
@@ -1945,9 +1761,7 @@ public class ChatImpl {
       UnreadCountsBatchRequest request) throws StreamException {
 
     return new StreamRequest<UnreadCountsBatchResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/chat/unread_batch",
         request,
@@ -1961,9 +1775,7 @@ public class ChatImpl {
     var pathParams = Map.of("user_id", userID);
 
     return new StreamRequest<Response>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/chat/users/{user_id}/event",
         request,

--- a/src/main/java/io/getstream/services/Common.java
+++ b/src/main/java/io/getstream/services/Common.java
@@ -46,6 +46,10 @@ public interface Common {
       throws StreamException;
 
   @NotNull
+  public StreamRequest<ImportBlockListResponse> importBlockList(
+      @NotNull String id, ImportBlockListRequest request) throws StreamException;
+
+  @NotNull
   public StreamRequest<Response> deleteBlockList(
       @NotNull String name, DeleteBlockListRequest request) throws StreamException;
 
@@ -167,34 +171,6 @@ public interface Common {
   @NotNull
   public StreamRequest<CreateImportV2TaskResponse> createImportV2Task(
       CreateImportV2TaskRequest request) throws StreamException;
-
-  @NotNull
-  public StreamRequest<DeleteExternalStorageResponse> deleteImporterExternalStorage(
-      DeleteImporterExternalStorageRequest request) throws StreamException;
-
-  @NotNull
-  public StreamRequest<DeleteExternalStorageResponse> deleteImporterExternalStorage()
-      throws StreamException;
-
-  @NotNull
-  public StreamRequest<GetExternalStorageResponse> getImporterExternalStorage(
-      GetImporterExternalStorageRequest request) throws StreamException;
-
-  @NotNull
-  public StreamRequest<GetExternalStorageResponse> getImporterExternalStorage()
-      throws StreamException;
-
-  @NotNull
-  public StreamRequest<UpsertExternalStorageResponse> upsertImporterExternalStorage(
-      UpsertImporterExternalStorageRequest request) throws StreamException;
-
-  @NotNull
-  public StreamRequest<ValidateExternalStorageResponse> validateImporterExternalStorage(
-      ValidateImporterExternalStorageRequest request) throws StreamException;
-
-  @NotNull
-  public StreamRequest<ValidateExternalStorageResponse> validateImporterExternalStorage()
-      throws StreamException;
 
   @NotNull
   public StreamRequest<DeleteImportV2TaskResponse> deleteImportV2Task(

--- a/src/main/java/io/getstream/services/CommonImpl.java
+++ b/src/main/java/io/getstream/services/CommonImpl.java
@@ -32,9 +32,7 @@ public class CommonImpl {
       throws StreamException {
 
     return new StreamRequest<GetApplicationResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/app",
         request,
@@ -51,14 +49,7 @@ public class CommonImpl {
   public StreamRequest<Response> updateApp(UpdateAppRequest request) throws StreamException {
 
     return new StreamRequest<Response>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
-        "PATCH",
-        "/api/v2/app",
-        request,
-        null,
-        new TypeReference<Response>() {});
+        client, "PATCH", "/api/v2/app", request, null, new TypeReference<Response>() {});
   }
 
   @NotNull
@@ -71,9 +62,7 @@ public class CommonImpl {
       throws StreamException {
 
     return new StreamRequest<ListBlockListResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/blocklists",
         request,
@@ -91,9 +80,7 @@ public class CommonImpl {
       throws StreamException {
 
     return new StreamRequest<CreateBlockListResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/blocklists",
         request,
@@ -107,9 +94,7 @@ public class CommonImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<ImportBlockListResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/blocklists/{id}/import",
         request,
@@ -123,9 +108,7 @@ public class CommonImpl {
     var pathParams = Map.of("name", name);
 
     return new StreamRequest<Response>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "DELETE",
         "/api/v2/blocklists/{name}",
         request,
@@ -144,9 +127,7 @@ public class CommonImpl {
     var pathParams = Map.of("name", name);
 
     return new StreamRequest<GetBlockListResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/blocklists/{name}",
         request,
@@ -166,9 +147,7 @@ public class CommonImpl {
     var pathParams = Map.of("name", name);
 
     return new StreamRequest<UpdateBlockListResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "PUT",
         "/api/v2/blocklists/{name}",
         request,
@@ -187,9 +166,7 @@ public class CommonImpl {
       throws StreamException {
 
     return new StreamRequest<CheckPushResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/check_push",
         request,
@@ -206,9 +183,7 @@ public class CommonImpl {
   public StreamRequest<CheckSNSResponse> checkSNS(CheckSNSRequest request) throws StreamException {
 
     return new StreamRequest<CheckSNSResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/check_sns",
         request,
@@ -225,9 +200,7 @@ public class CommonImpl {
   public StreamRequest<CheckSQSResponse> checkSQS(CheckSQSRequest request) throws StreamException {
 
     return new StreamRequest<CheckSQSResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/check_sqs",
         request,
@@ -244,14 +217,7 @@ public class CommonImpl {
   public StreamRequest<Response> deleteDevice(DeleteDeviceRequest request) throws StreamException {
 
     return new StreamRequest<Response>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
-        "DELETE",
-        "/api/v2/devices",
-        request,
-        null,
-        new TypeReference<Response>() {});
+        client, "DELETE", "/api/v2/devices", request, null, new TypeReference<Response>() {});
   }
 
   @NotNull
@@ -259,9 +225,7 @@ public class CommonImpl {
       throws StreamException {
 
     return new StreamRequest<ListDevicesResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/devices",
         request,
@@ -278,14 +242,7 @@ public class CommonImpl {
   public StreamRequest<Response> createDevice(CreateDeviceRequest request) throws StreamException {
 
     return new StreamRequest<Response>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
-        "POST",
-        "/api/v2/devices",
-        request,
-        null,
-        new TypeReference<Response>() {});
+        client, "POST", "/api/v2/devices", request, null, new TypeReference<Response>() {});
   }
 
   @NotNull
@@ -293,9 +250,7 @@ public class CommonImpl {
       throws StreamException {
 
     return new StreamRequest<ExportUsersResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/export/users",
         request,
@@ -308,9 +263,7 @@ public class CommonImpl {
       ListExternalStorageRequest request) throws StreamException {
 
     return new StreamRequest<ListExternalStorageResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/external_storage",
         request,
@@ -328,9 +281,7 @@ public class CommonImpl {
       CreateExternalStorageRequest request) throws StreamException {
 
     return new StreamRequest<CreateExternalStorageResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/external_storage",
         request,
@@ -344,9 +295,7 @@ public class CommonImpl {
     var pathParams = Map.of("name", name);
 
     return new StreamRequest<DeleteExternalStorageResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "DELETE",
         "/api/v2/external_storage/{name}",
         request,
@@ -366,9 +315,7 @@ public class CommonImpl {
     var pathParams = Map.of("name", name);
 
     return new StreamRequest<UpdateExternalStorageResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "PUT",
         "/api/v2/external_storage/{name}",
         request,
@@ -382,9 +329,7 @@ public class CommonImpl {
     var pathParams = Map.of("name", name);
 
     return new StreamRequest<CheckExternalStorageResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/external_storage/{name}/check",
         request,
@@ -403,9 +348,7 @@ public class CommonImpl {
       throws StreamException {
 
     return new StreamRequest<CreateGuestResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/guest",
         request,
@@ -418,9 +361,7 @@ public class CommonImpl {
       throws StreamException {
 
     return new StreamRequest<CreateImportURLResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/import_urls",
         request,
@@ -438,9 +379,7 @@ public class CommonImpl {
       throws StreamException {
 
     return new StreamRequest<ListImportsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/imports",
         request,
@@ -458,9 +397,7 @@ public class CommonImpl {
       throws StreamException {
 
     return new StreamRequest<CreateImportResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/imports",
         request,
@@ -473,9 +410,7 @@ public class CommonImpl {
       ListImportV2TasksRequest request) throws StreamException {
 
     return new StreamRequest<ListImportV2TasksResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/imports/v2",
         request,
@@ -493,9 +428,7 @@ public class CommonImpl {
       CreateImportV2TaskRequest request) throws StreamException {
 
     return new StreamRequest<CreateImportV2TaskResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/imports/v2",
         request,
@@ -509,9 +442,7 @@ public class CommonImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<DeleteImportV2TaskResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "DELETE",
         "/api/v2/imports/v2/{id}",
         request,
@@ -531,9 +462,7 @@ public class CommonImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<GetImportV2TaskResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/imports/v2/{id}",
         request,
@@ -553,9 +482,7 @@ public class CommonImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<CancelImportV2TaskResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/imports/v2/{id}/cancel",
         request,
@@ -575,9 +502,7 @@ public class CommonImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<GetImportResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/imports/{id}",
         request,
@@ -594,14 +519,7 @@ public class CommonImpl {
   public StreamRequest<GetOGResponse> getOG(GetOGRequest request) throws StreamException {
 
     return new StreamRequest<GetOGResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
-        "GET",
-        "/api/v2/og",
-        request,
-        null,
-        new TypeReference<GetOGResponse>() {});
+        client, "GET", "/api/v2/og", request, null, new TypeReference<GetOGResponse>() {});
   }
 
   @NotNull
@@ -609,9 +527,7 @@ public class CommonImpl {
       throws StreamException {
 
     return new StreamRequest<ListPermissionsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/permissions",
         request,
@@ -630,9 +546,7 @@ public class CommonImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<GetCustomPermissionResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/permissions/{id}",
         request,
@@ -650,28 +564,14 @@ public class CommonImpl {
   public StreamRequest<PollResponse> createPoll(CreatePollRequest request) throws StreamException {
 
     return new StreamRequest<PollResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
-        "POST",
-        "/api/v2/polls",
-        request,
-        null,
-        new TypeReference<PollResponse>() {});
+        client, "POST", "/api/v2/polls", request, null, new TypeReference<PollResponse>() {});
   }
 
   @NotNull
   public StreamRequest<PollResponse> updatePoll(UpdatePollRequest request) throws StreamException {
 
     return new StreamRequest<PollResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
-        "PUT",
-        "/api/v2/polls",
-        request,
-        null,
-        new TypeReference<PollResponse>() {});
+        client, "PUT", "/api/v2/polls", request, null, new TypeReference<PollResponse>() {});
   }
 
   @NotNull
@@ -679,9 +579,7 @@ public class CommonImpl {
       throws StreamException {
 
     return new StreamRequest<QueryPollsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/polls/query",
         request,
@@ -700,9 +598,7 @@ public class CommonImpl {
     var pathParams = Map.of("poll_id", pollID);
 
     return new StreamRequest<Response>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "DELETE",
         "/api/v2/polls/{poll_id}",
         request,
@@ -721,9 +617,7 @@ public class CommonImpl {
     var pathParams = Map.of("poll_id", pollID);
 
     return new StreamRequest<PollResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/polls/{poll_id}",
         request,
@@ -742,9 +636,7 @@ public class CommonImpl {
     var pathParams = Map.of("poll_id", pollID);
 
     return new StreamRequest<PollResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "PATCH",
         "/api/v2/polls/{poll_id}",
         request,
@@ -764,9 +656,7 @@ public class CommonImpl {
     var pathParams = Map.of("poll_id", pollID);
 
     return new StreamRequest<PollOptionResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/polls/{poll_id}/options",
         request,
@@ -780,9 +670,7 @@ public class CommonImpl {
     var pathParams = Map.of("poll_id", pollID);
 
     return new StreamRequest<PollOptionResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "PUT",
         "/api/v2/polls/{poll_id}/options",
         request,
@@ -800,9 +688,7 @@ public class CommonImpl {
             "option_id", optionID);
 
     return new StreamRequest<Response>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "DELETE",
         "/api/v2/polls/{poll_id}/options/{option_id}",
         request,
@@ -826,9 +712,7 @@ public class CommonImpl {
             "option_id", optionID);
 
     return new StreamRequest<PollOptionResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/polls/{poll_id}/options/{option_id}",
         request,
@@ -848,9 +732,7 @@ public class CommonImpl {
     var pathParams = Map.of("poll_id", pollID);
 
     return new StreamRequest<PollVotesResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/polls/{poll_id}/votes",
         request,
@@ -869,9 +751,7 @@ public class CommonImpl {
       UpdatePushNotificationPreferencesRequest request) throws StreamException {
 
     return new StreamRequest<UpsertPushPreferencesResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/push_preferences",
         request,
@@ -884,9 +764,7 @@ public class CommonImpl {
       ListPushProvidersRequest request) throws StreamException {
 
     return new StreamRequest<ListPushProvidersResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/push_providers",
         request,
@@ -904,9 +782,7 @@ public class CommonImpl {
       UpsertPushProviderRequest request) throws StreamException {
 
     return new StreamRequest<UpsertPushProviderResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/push_providers",
         request,
@@ -929,9 +805,7 @@ public class CommonImpl {
             "name", name);
 
     return new StreamRequest<Response>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "DELETE",
         "/api/v2/push_providers/{type}/{name}",
         request,
@@ -950,9 +824,7 @@ public class CommonImpl {
       throws StreamException {
 
     return new StreamRequest<GetPushTemplatesResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/push_templates",
         request,
@@ -965,9 +837,7 @@ public class CommonImpl {
       UpsertPushTemplateRequest request) throws StreamException {
 
     return new StreamRequest<UpsertPushTemplateResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/push_templates",
         request,
@@ -980,9 +850,7 @@ public class CommonImpl {
       throws StreamException {
 
     return new StreamRequest<GetRateLimitsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/rate_limits",
         request,
@@ -1000,14 +868,7 @@ public class CommonImpl {
       throws StreamException {
 
     return new StreamRequest<ListRolesResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
-        "GET",
-        "/api/v2/roles",
-        request,
-        null,
-        new TypeReference<ListRolesResponse>() {});
+        client, "GET", "/api/v2/roles", request, null, new TypeReference<ListRolesResponse>() {});
   }
 
   @NotNull
@@ -1020,14 +881,7 @@ public class CommonImpl {
       throws StreamException {
 
     return new StreamRequest<CreateRoleResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
-        "POST",
-        "/api/v2/roles",
-        request,
-        null,
-        new TypeReference<CreateRoleResponse>() {});
+        client, "POST", "/api/v2/roles", request, null, new TypeReference<CreateRoleResponse>() {});
   }
 
   @NotNull
@@ -1035,9 +889,7 @@ public class CommonImpl {
       throws StreamException {
 
     return new StreamRequest<SearchRolesResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/roles/search",
         request,
@@ -1051,9 +903,7 @@ public class CommonImpl {
     var pathParams = Map.of("name", name);
 
     return new StreamRequest<Response>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "DELETE",
         "/api/v2/roles/{name}",
         request,
@@ -1072,9 +922,7 @@ public class CommonImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<GetTaskResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/tasks/{id}",
         request,
@@ -1091,14 +939,7 @@ public class CommonImpl {
   public StreamRequest<Response> deleteFile(DeleteFileRequest request) throws StreamException {
 
     return new StreamRequest<Response>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
-        "DELETE",
-        "/api/v2/uploads/file",
-        request,
-        null,
-        new TypeReference<Response>() {});
+        client, "DELETE", "/api/v2/uploads/file", request, null, new TypeReference<Response>() {});
   }
 
   @NotNull
@@ -1111,9 +952,7 @@ public class CommonImpl {
       throws StreamException {
 
     return new StreamRequest<FileUploadResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/uploads/file",
         request,
@@ -1130,14 +969,7 @@ public class CommonImpl {
   public StreamRequest<Response> deleteImage(DeleteImageRequest request) throws StreamException {
 
     return new StreamRequest<Response>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
-        "DELETE",
-        "/api/v2/uploads/image",
-        request,
-        null,
-        new TypeReference<Response>() {});
+        client, "DELETE", "/api/v2/uploads/image", request, null, new TypeReference<Response>() {});
   }
 
   @NotNull
@@ -1150,9 +982,7 @@ public class CommonImpl {
       throws StreamException {
 
     return new StreamRequest<ImageUploadResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/uploads/image",
         request,
@@ -1170,9 +1000,7 @@ public class CommonImpl {
       throws StreamException {
 
     return new StreamRequest<ListUserGroupsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/usergroups",
         request,
@@ -1190,9 +1018,7 @@ public class CommonImpl {
       throws StreamException {
 
     return new StreamRequest<CreateUserGroupResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/usergroups",
         request,
@@ -1205,9 +1031,7 @@ public class CommonImpl {
       throws StreamException {
 
     return new StreamRequest<SearchUserGroupsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/usergroups/search",
         request,
@@ -1221,9 +1045,7 @@ public class CommonImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<Response>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "DELETE",
         "/api/v2/usergroups/{id}",
         request,
@@ -1242,9 +1064,7 @@ public class CommonImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<GetUserGroupResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/usergroups/{id}",
         request,
@@ -1264,9 +1084,7 @@ public class CommonImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<UpdateUserGroupResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "PUT",
         "/api/v2/usergroups/{id}",
         request,
@@ -1286,9 +1104,7 @@ public class CommonImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<AddUserGroupMembersResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/usergroups/{id}/members",
         request,
@@ -1302,9 +1118,7 @@ public class CommonImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<RemoveUserGroupMembersResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/usergroups/{id}/members/delete",
         request,
@@ -1317,14 +1131,7 @@ public class CommonImpl {
       throws StreamException {
 
     return new StreamRequest<QueryUsersResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
-        "GET",
-        "/api/v2/users",
-        request,
-        null,
-        new TypeReference<QueryUsersResponse>() {});
+        client, "GET", "/api/v2/users", request, null, new TypeReference<QueryUsersResponse>() {});
   }
 
   @NotNull
@@ -1337,9 +1144,7 @@ public class CommonImpl {
       throws StreamException {
 
     return new StreamRequest<UpdateUsersResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "PATCH",
         "/api/v2/users",
         request,
@@ -1352,9 +1157,7 @@ public class CommonImpl {
       throws StreamException {
 
     return new StreamRequest<UpdateUsersResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/users",
         request,
@@ -1367,9 +1170,7 @@ public class CommonImpl {
       throws StreamException {
 
     return new StreamRequest<GetBlockedUsersResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/users/block",
         request,
@@ -1387,9 +1188,7 @@ public class CommonImpl {
       throws StreamException {
 
     return new StreamRequest<BlockUsersResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/users/block",
         request,
@@ -1402,9 +1201,7 @@ public class CommonImpl {
       throws StreamException {
 
     return new StreamRequest<DeactivateUsersResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/users/deactivate",
         request,
@@ -1417,9 +1214,7 @@ public class CommonImpl {
       throws StreamException {
 
     return new StreamRequest<DeleteUsersResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/users/delete",
         request,
@@ -1432,9 +1227,7 @@ public class CommonImpl {
       GetUserLiveLocationsRequest request) throws StreamException {
 
     return new StreamRequest<SharedLocationsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/users/live_locations",
         request,
@@ -1452,9 +1245,7 @@ public class CommonImpl {
       throws StreamException {
 
     return new StreamRequest<SharedLocationResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "PUT",
         "/api/v2/users/live_locations",
         request,
@@ -1467,9 +1258,7 @@ public class CommonImpl {
       throws StreamException {
 
     return new StreamRequest<ReactivateUsersResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/users/reactivate",
         request,
@@ -1481,14 +1270,7 @@ public class CommonImpl {
   public StreamRequest<Response> restoreUsers(RestoreUsersRequest request) throws StreamException {
 
     return new StreamRequest<Response>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
-        "POST",
-        "/api/v2/users/restore",
-        request,
-        null,
-        new TypeReference<Response>() {});
+        client, "POST", "/api/v2/users/restore", request, null, new TypeReference<Response>() {});
   }
 
   @NotNull
@@ -1496,9 +1278,7 @@ public class CommonImpl {
       throws StreamException {
 
     return new StreamRequest<UnblockUsersResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/users/unblock",
         request,
@@ -1512,9 +1292,7 @@ public class CommonImpl {
     var pathParams = Map.of("user_id", userID);
 
     return new StreamRequest<DeactivateUserResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/users/{user_id}/deactivate",
         request,
@@ -1534,9 +1312,7 @@ public class CommonImpl {
     var pathParams = Map.of("user_id", userID);
 
     return new StreamRequest<ExportUserResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/users/{user_id}/export",
         request,
@@ -1556,9 +1332,7 @@ public class CommonImpl {
     var pathParams = Map.of("user_id", userID);
 
     return new StreamRequest<ReactivateUserResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/users/{user_id}/reactivate",
         request,

--- a/src/main/java/io/getstream/services/CommonImpl.java
+++ b/src/main/java/io/getstream/services/CommonImpl.java
@@ -102,6 +102,22 @@ public class CommonImpl {
   }
 
   @NotNull
+  public StreamRequest<ImportBlockListResponse> importBlockList(
+      @NotNull String id, ImportBlockListRequest request) throws StreamException {
+    var pathParams = Map.of("id", id);
+
+    return new StreamRequest<ImportBlockListResponse>(
+        client.getHttpClient(),
+        client.getObjectMapper(),
+        client.getBaseUrl(),
+        "POST",
+        "/api/v2/blocklists/{id}/import",
+        request,
+        pathParams,
+        new TypeReference<ImportBlockListResponse>() {});
+  }
+
+  @NotNull
   public StreamRequest<Response> deleteBlockList(
       @NotNull String name, DeleteBlockListRequest request) throws StreamException {
     var pathParams = Map.of("name", name);
@@ -485,84 +501,6 @@ public class CommonImpl {
         request,
         null,
         new TypeReference<CreateImportV2TaskResponse>() {});
-  }
-
-  @NotNull
-  public StreamRequest<DeleteExternalStorageResponse> deleteImporterExternalStorage(
-      DeleteImporterExternalStorageRequest request) throws StreamException {
-
-    return new StreamRequest<DeleteExternalStorageResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
-        "DELETE",
-        "/api/v2/imports/v2/external-storage",
-        request,
-        null,
-        new TypeReference<DeleteExternalStorageResponse>() {});
-  }
-
-  @NotNull
-  public StreamRequest<DeleteExternalStorageResponse> deleteImporterExternalStorage()
-      throws StreamException {
-    return deleteImporterExternalStorage(new DeleteImporterExternalStorageRequest());
-  }
-
-  @NotNull
-  public StreamRequest<GetExternalStorageResponse> getImporterExternalStorage(
-      GetImporterExternalStorageRequest request) throws StreamException {
-
-    return new StreamRequest<GetExternalStorageResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
-        "GET",
-        "/api/v2/imports/v2/external-storage",
-        request,
-        null,
-        new TypeReference<GetExternalStorageResponse>() {});
-  }
-
-  @NotNull
-  public StreamRequest<GetExternalStorageResponse> getImporterExternalStorage()
-      throws StreamException {
-    return getImporterExternalStorage(new GetImporterExternalStorageRequest());
-  }
-
-  @NotNull
-  public StreamRequest<UpsertExternalStorageResponse> upsertImporterExternalStorage(
-      UpsertImporterExternalStorageRequest request) throws StreamException {
-
-    return new StreamRequest<UpsertExternalStorageResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
-        "PUT",
-        "/api/v2/imports/v2/external-storage",
-        request,
-        null,
-        new TypeReference<UpsertExternalStorageResponse>() {});
-  }
-
-  @NotNull
-  public StreamRequest<ValidateExternalStorageResponse> validateImporterExternalStorage(
-      ValidateImporterExternalStorageRequest request) throws StreamException {
-
-    return new StreamRequest<ValidateExternalStorageResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
-        "POST",
-        "/api/v2/imports/v2/external-storage/validate",
-        request,
-        null,
-        new TypeReference<ValidateExternalStorageResponse>() {});
-  }
-
-  @NotNull
-  public StreamRequest<ValidateExternalStorageResponse> validateImporterExternalStorage()
-      throws StreamException {
-    return validateImporterExternalStorage(new ValidateImporterExternalStorageRequest());
   }
 
   @NotNull

--- a/src/main/java/io/getstream/services/FeedsImpl.java
+++ b/src/main/java/io/getstream/services/FeedsImpl.java
@@ -32,9 +32,7 @@ public class FeedsImpl {
       throws StreamException {
 
     return new StreamRequest<AddActivityResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/feeds/activities",
         request,
@@ -47,9 +45,7 @@ public class FeedsImpl {
       throws StreamException {
 
     return new StreamRequest<UpsertActivitiesResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/feeds/activities/batch",
         request,
@@ -62,9 +58,7 @@ public class FeedsImpl {
       UpdateActivitiesPartialBatchRequest request) throws StreamException {
 
     return new StreamRequest<UpdateActivitiesPartialBatchResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "PATCH",
         "/api/v2/feeds/activities/batch/partial",
         request,
@@ -77,9 +71,7 @@ public class FeedsImpl {
       throws StreamException {
 
     return new StreamRequest<DeleteActivitiesResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/feeds/activities/delete",
         request,
@@ -92,9 +84,7 @@ public class FeedsImpl {
       TrackActivityMetricsRequest request) throws StreamException {
 
     return new StreamRequest<TrackActivityMetricsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/feeds/activities/metrics/track",
         request,
@@ -107,9 +97,7 @@ public class FeedsImpl {
       throws StreamException {
 
     return new StreamRequest<QueryActivitiesResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/feeds/activities/query",
         request,
@@ -127,9 +115,7 @@ public class FeedsImpl {
       BatchQueryActivityReactionsRequest request) throws StreamException {
 
     return new StreamRequest<BatchQueryActivityReactionsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/feeds/activities/reactions/query",
         request,
@@ -143,9 +129,7 @@ public class FeedsImpl {
     var pathParams = Map.of("activity_id", activityID);
 
     return new StreamRequest<DeleteBookmarkResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "DELETE",
         "/api/v2/feeds/activities/{activity_id}/bookmarks",
         request,
@@ -165,9 +149,7 @@ public class FeedsImpl {
     var pathParams = Map.of("activity_id", activityID);
 
     return new StreamRequest<UpdateBookmarkResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "PATCH",
         "/api/v2/feeds/activities/{activity_id}/bookmarks",
         request,
@@ -187,9 +169,7 @@ public class FeedsImpl {
     var pathParams = Map.of("activity_id", activityID);
 
     return new StreamRequest<AddBookmarkResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/feeds/activities/{activity_id}/bookmarks",
         request,
@@ -209,9 +189,7 @@ public class FeedsImpl {
     var pathParams = Map.of("activity_id", activityID);
 
     return new StreamRequest<ActivityFeedbackResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/feeds/activities/{activity_id}/feedback",
         request,
@@ -235,9 +213,7 @@ public class FeedsImpl {
             "poll_id", pollID);
 
     return new StreamRequest<PollVoteResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/feeds/activities/{activity_id}/polls/{poll_id}/vote",
         request,
@@ -265,9 +241,7 @@ public class FeedsImpl {
             "vote_id", voteID);
 
     return new StreamRequest<PollVoteResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "DELETE",
         "/api/v2/feeds/activities/{activity_id}/polls/{poll_id}/vote/{vote_id}",
         request,
@@ -288,9 +262,7 @@ public class FeedsImpl {
     var pathParams = Map.of("activity_id", activityID);
 
     return new StreamRequest<AddReactionResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/feeds/activities/{activity_id}/reactions",
         request,
@@ -304,9 +276,7 @@ public class FeedsImpl {
     var pathParams = Map.of("activity_id", activityID);
 
     return new StreamRequest<QueryActivityReactionsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/feeds/activities/{activity_id}/reactions/query",
         request,
@@ -330,9 +300,7 @@ public class FeedsImpl {
             "type", type);
 
     return new StreamRequest<DeleteActivityReactionResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "DELETE",
         "/api/v2/feeds/activities/{activity_id}/reactions/{type}",
         request,
@@ -352,9 +320,7 @@ public class FeedsImpl {
     var pathParams = Map.of("activity_id", activityID);
 
     return new StreamRequest<QueryActivitySharesResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/feeds/activities/{activity_id}/shares",
         request,
@@ -374,9 +340,7 @@ public class FeedsImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<DeleteActivityResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "DELETE",
         "/api/v2/feeds/activities/{id}",
         request,
@@ -396,9 +360,7 @@ public class FeedsImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<GetActivityResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/feeds/activities/{id}",
         request,
@@ -417,9 +379,7 @@ public class FeedsImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<UpdateActivityPartialResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "PATCH",
         "/api/v2/feeds/activities/{id}",
         request,
@@ -439,9 +399,7 @@ public class FeedsImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<UpdateActivityResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "PUT",
         "/api/v2/feeds/activities/{id}",
         request,
@@ -461,9 +419,7 @@ public class FeedsImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<RestoreActivityResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/feeds/activities/{id}/restore",
         request,
@@ -483,9 +439,7 @@ public class FeedsImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<TranslateActivityResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/feeds/activities/{id}/translate",
         request,
@@ -498,9 +452,7 @@ public class FeedsImpl {
       QueryBookmarkFoldersRequest request) throws StreamException {
 
     return new StreamRequest<QueryBookmarkFoldersResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/feeds/bookmark_folders/query",
         request,
@@ -519,9 +471,7 @@ public class FeedsImpl {
     var pathParams = Map.of("folder_id", folderID);
 
     return new StreamRequest<DeleteBookmarkFolderResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "DELETE",
         "/api/v2/feeds/bookmark_folders/{folder_id}",
         request,
@@ -541,9 +491,7 @@ public class FeedsImpl {
     var pathParams = Map.of("folder_id", folderID);
 
     return new StreamRequest<UpdateBookmarkFolderResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "PATCH",
         "/api/v2/feeds/bookmark_folders/{folder_id}",
         request,
@@ -562,9 +510,7 @@ public class FeedsImpl {
       throws StreamException {
 
     return new StreamRequest<QueryBookmarksResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/feeds/bookmarks/query",
         request,
@@ -582,9 +528,7 @@ public class FeedsImpl {
       DeleteCollectionsRequest request) throws StreamException {
 
     return new StreamRequest<DeleteCollectionsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "DELETE",
         "/api/v2/feeds/collections",
         request,
@@ -597,9 +541,7 @@ public class FeedsImpl {
       throws StreamException {
 
     return new StreamRequest<ReadCollectionsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/feeds/collections",
         request,
@@ -617,9 +559,7 @@ public class FeedsImpl {
       UpdateCollectionsRequest request) throws StreamException {
 
     return new StreamRequest<UpdateCollectionsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "PATCH",
         "/api/v2/feeds/collections",
         request,
@@ -632,9 +572,7 @@ public class FeedsImpl {
       CreateCollectionsRequest request) throws StreamException {
 
     return new StreamRequest<CreateCollectionsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/feeds/collections",
         request,
@@ -647,9 +585,7 @@ public class FeedsImpl {
       UpsertCollectionsRequest request) throws StreamException {
 
     return new StreamRequest<UpsertCollectionsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "PUT",
         "/api/v2/feeds/collections",
         request,
@@ -662,9 +598,7 @@ public class FeedsImpl {
       throws StreamException {
 
     return new StreamRequest<QueryCollectionsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/feeds/collections/query",
         request,
@@ -682,9 +616,7 @@ public class FeedsImpl {
       throws StreamException {
 
     return new StreamRequest<GetCommentsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/feeds/comments",
         request,
@@ -697,9 +629,7 @@ public class FeedsImpl {
       throws StreamException {
 
     return new StreamRequest<AddCommentResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/feeds/comments",
         request,
@@ -717,9 +647,7 @@ public class FeedsImpl {
       throws StreamException {
 
     return new StreamRequest<AddCommentsBatchResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/feeds/comments/batch",
         request,
@@ -732,9 +660,7 @@ public class FeedsImpl {
       throws StreamException {
 
     return new StreamRequest<QueryCommentsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/feeds/comments/query",
         request,
@@ -747,9 +673,7 @@ public class FeedsImpl {
       BatchQueryCommentReactionsRequest request) throws StreamException {
 
     return new StreamRequest<BatchQueryCommentReactionsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/feeds/comments/reactions/query",
         request,
@@ -763,9 +687,7 @@ public class FeedsImpl {
     var pathParams = Map.of("comment_id", commentID);
 
     return new StreamRequest<DeleteCommentBookmarkResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "DELETE",
         "/api/v2/feeds/comments/{comment_id}/bookmarks",
         request,
@@ -785,9 +707,7 @@ public class FeedsImpl {
     var pathParams = Map.of("comment_id", commentID);
 
     return new StreamRequest<UpdateCommentBookmarkResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "PATCH",
         "/api/v2/feeds/comments/{comment_id}/bookmarks",
         request,
@@ -807,9 +727,7 @@ public class FeedsImpl {
     var pathParams = Map.of("comment_id", commentID);
 
     return new StreamRequest<AddCommentBookmarkResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/feeds/comments/{comment_id}/bookmarks",
         request,
@@ -829,9 +747,7 @@ public class FeedsImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<DeleteCommentResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "DELETE",
         "/api/v2/feeds/comments/{id}",
         request,
@@ -851,9 +767,7 @@ public class FeedsImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<GetCommentResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/feeds/comments/{id}",
         request,
@@ -872,9 +786,7 @@ public class FeedsImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<UpdateCommentResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "PATCH",
         "/api/v2/feeds/comments/{id}",
         request,
@@ -894,9 +806,7 @@ public class FeedsImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<UpdateCommentPartialResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/feeds/comments/{id}/partial",
         request,
@@ -916,9 +826,7 @@ public class FeedsImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<AddCommentReactionResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/feeds/comments/{id}/reactions",
         request,
@@ -932,9 +840,7 @@ public class FeedsImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<QueryCommentReactionsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/feeds/comments/{id}/reactions/query",
         request,
@@ -958,9 +864,7 @@ public class FeedsImpl {
             "type", type);
 
     return new StreamRequest<DeleteCommentReactionResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "DELETE",
         "/api/v2/feeds/comments/{id}/reactions/{type}",
         request,
@@ -980,9 +884,7 @@ public class FeedsImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<GetCommentRepliesResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/feeds/comments/{id}/replies",
         request,
@@ -1002,9 +904,7 @@ public class FeedsImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<RestoreCommentResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/feeds/comments/{id}/restore",
         request,
@@ -1024,9 +924,7 @@ public class FeedsImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<TranslateCommentResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/feeds/comments/{id}/translate",
         request,
@@ -1039,9 +937,7 @@ public class FeedsImpl {
       throws StreamException {
 
     return new StreamRequest<ListFeedGroupsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/feeds/feed_groups",
         request,
@@ -1059,9 +955,7 @@ public class FeedsImpl {
       throws StreamException {
 
     return new StreamRequest<CreateFeedGroupResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/feeds/feed_groups",
         request,
@@ -1079,9 +973,7 @@ public class FeedsImpl {
             "feed_id", feedID);
 
     return new StreamRequest<DeleteFeedResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "DELETE",
         "/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}",
         request,
@@ -1105,9 +997,7 @@ public class FeedsImpl {
             "feed_id", feedID);
 
     return new StreamRequest<GetOrCreateFeedResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}",
         request,
@@ -1131,9 +1021,7 @@ public class FeedsImpl {
             "feed_id", feedID);
 
     return new StreamRequest<UpdateFeedResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "PUT",
         "/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}",
         request,
@@ -1157,9 +1045,7 @@ public class FeedsImpl {
             "feed_id", feedID);
 
     return new StreamRequest<Response>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}/activities/mark/batch",
         request,
@@ -1187,9 +1073,7 @@ public class FeedsImpl {
             "activity_id", activityID);
 
     return new StreamRequest<UnpinActivityResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "DELETE",
         "/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}/activities/{activity_id}/pin",
         request,
@@ -1218,9 +1102,7 @@ public class FeedsImpl {
             "activity_id", activityID);
 
     return new StreamRequest<PinActivityResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}/activities/{activity_id}/pin",
         request,
@@ -1245,9 +1127,7 @@ public class FeedsImpl {
             "feed_id", feedID);
 
     return new StreamRequest<ChangeFeedVisibilityResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}/change_visibility",
         request,
@@ -1265,9 +1145,7 @@ public class FeedsImpl {
             "feed_id", feedID);
 
     return new StreamRequest<UpdateFeedMembersResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "PATCH",
         "/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}/members",
         request,
@@ -1285,9 +1163,7 @@ public class FeedsImpl {
             "feed_group_id", feedGroupID);
 
     return new StreamRequest<AcceptFeedMemberInviteResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}/members/accept",
         request,
@@ -1311,9 +1187,7 @@ public class FeedsImpl {
             "feed_id", feedID);
 
     return new StreamRequest<QueryFeedMembersResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}/members/query",
         request,
@@ -1337,9 +1211,7 @@ public class FeedsImpl {
             "feed_id", feedID);
 
     return new StreamRequest<RejectFeedMemberInviteResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}/members/reject",
         request,
@@ -1363,9 +1235,7 @@ public class FeedsImpl {
             "feed_id", feedID);
 
     return new StreamRequest<QueryPinnedActivitiesResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}/pinned_activities/query",
         request,
@@ -1385,9 +1255,7 @@ public class FeedsImpl {
     var pathParams = Map.of("feed_group_id", feedGroupID);
 
     return new StreamRequest<GetFollowSuggestionsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/feeds/feed_groups/{feed_group_id}/follow_suggestions",
         request,
@@ -1407,9 +1275,7 @@ public class FeedsImpl {
     var pathParams = Map.of("feed_group_id", feedGroupID);
 
     return new StreamRequest<RestoreFeedGroupResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/feeds/feed_groups/{feed_group_id}/restore",
         request,
@@ -1429,9 +1295,7 @@ public class FeedsImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<DeleteFeedGroupResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "DELETE",
         "/api/v2/feeds/feed_groups/{id}",
         request,
@@ -1451,9 +1315,7 @@ public class FeedsImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<GetFeedGroupResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/feeds/feed_groups/{id}",
         request,
@@ -1473,9 +1335,7 @@ public class FeedsImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<GetOrCreateFeedGroupResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/feeds/feed_groups/{id}",
         request,
@@ -1495,9 +1355,7 @@ public class FeedsImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<UpdateFeedGroupResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "PUT",
         "/api/v2/feeds/feed_groups/{id}",
         request,
@@ -1516,9 +1374,7 @@ public class FeedsImpl {
       throws StreamException {
 
     return new StreamRequest<ListFeedViewsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/feeds/feed_views",
         request,
@@ -1536,9 +1392,7 @@ public class FeedsImpl {
       throws StreamException {
 
     return new StreamRequest<CreateFeedViewResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/feeds/feed_views",
         request,
@@ -1552,9 +1406,7 @@ public class FeedsImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<DeleteFeedViewResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "DELETE",
         "/api/v2/feeds/feed_views/{id}",
         request,
@@ -1574,9 +1426,7 @@ public class FeedsImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<GetFeedViewResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/feeds/feed_views/{id}",
         request,
@@ -1595,9 +1445,7 @@ public class FeedsImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<GetOrCreateFeedViewResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/feeds/feed_views/{id}",
         request,
@@ -1617,9 +1465,7 @@ public class FeedsImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<UpdateFeedViewResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "PUT",
         "/api/v2/feeds/feed_views/{id}",
         request,
@@ -1638,9 +1484,7 @@ public class FeedsImpl {
       ListFeedVisibilitiesRequest request) throws StreamException {
 
     return new StreamRequest<ListFeedVisibilitiesResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/feeds/feed_visibilities",
         request,
@@ -1659,9 +1503,7 @@ public class FeedsImpl {
     var pathParams = Map.of("name", name);
 
     return new StreamRequest<GetFeedVisibilityResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/feeds/feed_visibilities/{name}",
         request,
@@ -1681,9 +1523,7 @@ public class FeedsImpl {
     var pathParams = Map.of("name", name);
 
     return new StreamRequest<UpdateFeedVisibilityResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "PUT",
         "/api/v2/feeds/feed_visibilities/{name}",
         request,
@@ -1702,9 +1542,7 @@ public class FeedsImpl {
       throws StreamException {
 
     return new StreamRequest<CreateFeedsBatchResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/feeds/feeds/batch",
         request,
@@ -1717,9 +1555,7 @@ public class FeedsImpl {
       throws StreamException {
 
     return new StreamRequest<DeleteFeedsBatchResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/feeds/feeds/delete",
         request,
@@ -1731,9 +1567,7 @@ public class FeedsImpl {
   public StreamRequest<OwnBatchResponse> ownBatch(OwnBatchRequest request) throws StreamException {
 
     return new StreamRequest<OwnBatchResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/feeds/feeds/own/batch",
         request,
@@ -1746,9 +1580,7 @@ public class FeedsImpl {
       throws StreamException {
 
     return new StreamRequest<QueryFeedsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/feeds/feeds/query",
         request,
@@ -1766,9 +1598,7 @@ public class FeedsImpl {
       GetFeedsRateLimitsRequest request) throws StreamException {
 
     return new StreamRequest<GetFeedsRateLimitsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/feeds/feeds/rate_limits",
         request,
@@ -1786,9 +1616,7 @@ public class FeedsImpl {
       throws StreamException {
 
     return new StreamRequest<UpdateFollowResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "PATCH",
         "/api/v2/feeds/follows",
         request,
@@ -1800,9 +1628,7 @@ public class FeedsImpl {
   public StreamRequest<SingleFollowResponse> follow(FollowRequest request) throws StreamException {
 
     return new StreamRequest<SingleFollowResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/feeds/follows",
         request,
@@ -1815,9 +1641,7 @@ public class FeedsImpl {
       throws StreamException {
 
     return new StreamRequest<AcceptFollowResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/feeds/follows/accept",
         request,
@@ -1830,9 +1654,7 @@ public class FeedsImpl {
       throws StreamException {
 
     return new StreamRequest<FollowBatchResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/feeds/follows/batch",
         request,
@@ -1845,9 +1667,7 @@ public class FeedsImpl {
       throws StreamException {
 
     return new StreamRequest<FollowBatchResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/feeds/follows/batch/upsert",
         request,
@@ -1860,9 +1680,7 @@ public class FeedsImpl {
       throws StreamException {
 
     return new StreamRequest<QueryFollowsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/feeds/follows/query",
         request,
@@ -1880,9 +1698,7 @@ public class FeedsImpl {
       throws StreamException {
 
     return new StreamRequest<RejectFollowResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/feeds/follows/reject",
         request,
@@ -1895,9 +1711,7 @@ public class FeedsImpl {
       GetOrCreateFollowRequest request) throws StreamException {
 
     return new StreamRequest<GetOrCreateFollowResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/feeds/follows/upsert",
         request,
@@ -1915,9 +1729,7 @@ public class FeedsImpl {
             "target", target);
 
     return new StreamRequest<UnfollowResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "DELETE",
         "/api/v2/feeds/follows/{source}/{target}",
         request,
@@ -1936,9 +1748,7 @@ public class FeedsImpl {
       CreateMembershipLevelRequest request) throws StreamException {
 
     return new StreamRequest<CreateMembershipLevelResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/feeds/membership_levels",
         request,
@@ -1951,9 +1761,7 @@ public class FeedsImpl {
       QueryMembershipLevelsRequest request) throws StreamException {
 
     return new StreamRequest<QueryMembershipLevelsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/feeds/membership_levels/query",
         request,
@@ -1973,9 +1781,7 @@ public class FeedsImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<Response>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "DELETE",
         "/api/v2/feeds/membership_levels/{id}",
         request,
@@ -1994,9 +1800,7 @@ public class FeedsImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<UpdateMembershipLevelResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "PATCH",
         "/api/v2/feeds/membership_levels/{id}",
         request,
@@ -2015,9 +1819,7 @@ public class FeedsImpl {
       QueryRevisionHistoryRequest request) throws StreamException {
 
     return new StreamRequest<QueryRevisionHistoryResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/feeds/revisions/query",
         request,
@@ -2030,9 +1832,7 @@ public class FeedsImpl {
       QueryFeedsUsageStatsRequest request) throws StreamException {
 
     return new StreamRequest<QueryFeedsUsageStatsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/feeds/stats/usage",
         request,
@@ -2050,9 +1850,7 @@ public class FeedsImpl {
       throws StreamException {
 
     return new StreamRequest<UnfollowBatchResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/feeds/unfollow/batch",
         request,
@@ -2065,9 +1863,7 @@ public class FeedsImpl {
       GetOrCreateUnfollowsRequest request) throws StreamException {
 
     return new StreamRequest<UnfollowBatchResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/feeds/unfollow/batch/upsert",
         request,
@@ -2080,9 +1876,7 @@ public class FeedsImpl {
       GetOrCreateUnfollowRequest request) throws StreamException {
 
     return new StreamRequest<GetOrCreateUnfollowResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/feeds/unfollow/upsert",
         request,
@@ -2096,9 +1890,7 @@ public class FeedsImpl {
     var pathParams = Map.of("user_id", userID);
 
     return new StreamRequest<DeleteFeedUserDataResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/feeds/users/{user_id}/delete",
         request,
@@ -2118,9 +1910,7 @@ public class FeedsImpl {
     var pathParams = Map.of("user_id", userID);
 
     return new StreamRequest<ExportFeedUserDataResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/feeds/users/{user_id}/export",
         request,
@@ -2140,9 +1930,7 @@ public class FeedsImpl {
     var pathParams = Map.of("user_id", userID);
 
     return new StreamRequest<GetUserInterestsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/feeds/users/{user_id}/interests",
         request,

--- a/src/main/java/io/getstream/services/Moderation.java
+++ b/src/main/java/io/getstream/services/Moderation.java
@@ -187,17 +187,19 @@ public interface Moderation {
 
   @NotNull
   public StreamRequest<DeleteModerationRuleResponse> deleteModerationRule(
-      DeleteModerationRuleRequest request) throws StreamException;
+      @NotNull String id, DeleteModerationRuleRequest request) throws StreamException;
 
   @NotNull
-  public StreamRequest<DeleteModerationRuleResponse> deleteModerationRule() throws StreamException;
+  public StreamRequest<DeleteModerationRuleResponse> deleteModerationRule(@NotNull String id)
+      throws StreamException;
 
   @NotNull
   public StreamRequest<GetModerationRuleResponse> getModerationRule(
-      GetModerationRuleRequest request) throws StreamException;
+      @NotNull String id, GetModerationRuleRequest request) throws StreamException;
 
   @NotNull
-  public StreamRequest<GetModerationRuleResponse> getModerationRule() throws StreamException;
+  public StreamRequest<GetModerationRuleResponse> getModerationRule(@NotNull String id)
+      throws StreamException;
 
   @NotNull
   public StreamRequest<QueryModerationRulesResponse> queryModerationRules(

--- a/src/main/java/io/getstream/services/ModerationImpl.java
+++ b/src/main/java/io/getstream/services/ModerationImpl.java
@@ -32,9 +32,7 @@ public class ModerationImpl {
       throws StreamException {
 
     return new StreamRequest<GetActionConfigResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/moderation/action_config",
         request,
@@ -52,9 +50,7 @@ public class ModerationImpl {
       UpsertActionConfigRequest request) throws StreamException {
 
     return new StreamRequest<UpsertActionConfigResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/moderation/action_config",
         request,
@@ -67,9 +63,7 @@ public class ModerationImpl {
       BulkUpsertActionConfigRequest request) throws StreamException {
 
     return new StreamRequest<BulkUpsertActionConfigResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/moderation/action_config/bulk",
         request,
@@ -82,9 +76,7 @@ public class ModerationImpl {
       BulkDeleteActionConfigRequest request) throws StreamException {
 
     return new StreamRequest<BulkDeleteActionConfigResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/moderation/action_config/bulk_delete",
         request,
@@ -98,9 +90,7 @@ public class ModerationImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<DeleteActionConfigResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "DELETE",
         "/api/v2/moderation/action_config/{id}",
         request,
@@ -119,9 +109,7 @@ public class ModerationImpl {
       throws StreamException {
 
     return new StreamRequest<InsertActionLogResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/moderation/action_logs",
         request,
@@ -133,9 +121,7 @@ public class ModerationImpl {
   public StreamRequest<AnalyzeResponse> analyze(AnalyzeRequest request) throws StreamException {
 
     return new StreamRequest<AnalyzeResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/moderation/analyze",
         request,
@@ -152,9 +138,7 @@ public class ModerationImpl {
   public StreamRequest<AppealResponse> appeal(AppealRequest request) throws StreamException {
 
     return new StreamRequest<AppealResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/moderation/appeal",
         request,
@@ -168,9 +152,7 @@ public class ModerationImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<GetAppealResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/moderation/appeal/{id}",
         request,
@@ -188,9 +170,7 @@ public class ModerationImpl {
       throws StreamException {
 
     return new StreamRequest<QueryAppealsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/moderation/appeals",
         request,
@@ -208,9 +188,7 @@ public class ModerationImpl {
       BulkActionAppealsRequest request) throws StreamException {
 
     return new StreamRequest<BulkActionAppealsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/moderation/appeals/bulk_action",
         request,
@@ -222,9 +200,7 @@ public class ModerationImpl {
   public StreamRequest<ModerationBanResponse> ban(BanRequest request) throws StreamException {
 
     return new StreamRequest<ModerationBanResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/moderation/ban",
         request,
@@ -237,9 +213,7 @@ public class ModerationImpl {
       BulkImageModerationRequest request) throws StreamException {
 
     return new StreamRequest<BulkImageModerationResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/moderation/bulk_image_moderation",
         request,
@@ -251,9 +225,7 @@ public class ModerationImpl {
   public StreamRequest<BypassResponse> bypass(BypassRequest request) throws StreamException {
 
     return new StreamRequest<BypassResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/moderation/bypass",
         request,
@@ -265,9 +237,7 @@ public class ModerationImpl {
   public StreamRequest<CheckResponse> check(CheckRequest request) throws StreamException {
 
     return new StreamRequest<CheckResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/moderation/check",
         request,
@@ -280,9 +250,7 @@ public class ModerationImpl {
       throws StreamException {
 
     return new StreamRequest<CheckS3AccessResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/moderation/check_s3_access",
         request,
@@ -300,9 +268,7 @@ public class ModerationImpl {
       throws StreamException {
 
     return new StreamRequest<UpsertConfigResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/moderation/config",
         request,
@@ -316,9 +282,7 @@ public class ModerationImpl {
     var pathParams = Map.of("key", key);
 
     return new StreamRequest<DeleteModerationConfigResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "DELETE",
         "/api/v2/moderation/config/{key}",
         request,
@@ -338,9 +302,7 @@ public class ModerationImpl {
     var pathParams = Map.of("key", key);
 
     return new StreamRequest<GetConfigResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/moderation/config/{key}",
         request,
@@ -358,9 +320,7 @@ public class ModerationImpl {
       QueryModerationConfigsRequest request) throws StreamException {
 
     return new StreamRequest<QueryModerationConfigsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/moderation/configs",
         request,
@@ -379,9 +339,7 @@ public class ModerationImpl {
       throws StreamException {
 
     return new StreamRequest<CustomCheckResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/moderation/custom_check",
         request,
@@ -394,9 +352,7 @@ public class ModerationImpl {
       V2DeleteTemplateRequest request) throws StreamException {
 
     return new StreamRequest<DeleteModerationTemplateResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "DELETE",
         "/api/v2/moderation/feeds_moderation_template",
         request,
@@ -414,9 +370,7 @@ public class ModerationImpl {
       V2QueryTemplatesRequest request) throws StreamException {
 
     return new StreamRequest<QueryFeedModerationTemplatesResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/moderation/feeds_moderation_template",
         request,
@@ -435,9 +389,7 @@ public class ModerationImpl {
       V2UpsertTemplateRequest request) throws StreamException {
 
     return new StreamRequest<UpsertModerationTemplateResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/moderation/feeds_moderation_template",
         request,
@@ -449,9 +401,7 @@ public class ModerationImpl {
   public StreamRequest<FlagItemResponse> flag(FlagRequest request) throws StreamException {
 
     return new StreamRequest<FlagItemResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/moderation/flag",
         request,
@@ -464,9 +414,7 @@ public class ModerationImpl {
       throws StreamException {
 
     return new StreamRequest<GetFlagCountResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/moderation/flag_count",
         request,
@@ -479,9 +427,7 @@ public class ModerationImpl {
       QueryModerationFlagsRequest request) throws StreamException {
 
     return new StreamRequest<QueryModerationFlagsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/moderation/flags",
         request,
@@ -498,9 +444,7 @@ public class ModerationImpl {
   public StreamRequest<LabelsResponse> labels(LabelsRequest request) throws StreamException {
 
     return new StreamRequest<LabelsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/moderation/labels",
         request,
@@ -513,9 +457,7 @@ public class ModerationImpl {
       QueryLabelResultsRequest request) throws StreamException {
 
     return new StreamRequest<QueryLabelResultsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/moderation/labels/results",
         request,
@@ -533,9 +475,7 @@ public class ModerationImpl {
       QueryModerationLogsRequest request) throws StreamException {
 
     return new StreamRequest<QueryModerationLogsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/moderation/logs",
         request,
@@ -553,9 +493,7 @@ public class ModerationImpl {
       UpsertModerationRuleRequest request) throws StreamException {
 
     return new StreamRequest<UpsertModerationRuleResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/moderation/moderation_rule",
         request,
@@ -569,9 +507,7 @@ public class ModerationImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<DeleteModerationRuleResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "DELETE",
         "/api/v2/moderation/moderation_rule/{id}",
         request,
@@ -591,9 +527,7 @@ public class ModerationImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<GetModerationRuleResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/moderation/moderation_rule/{id}",
         request,
@@ -612,9 +546,7 @@ public class ModerationImpl {
       QueryModerationRulesRequest request) throws StreamException {
 
     return new StreamRequest<QueryModerationRulesResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/moderation/moderation_rules",
         request,
@@ -631,9 +563,7 @@ public class ModerationImpl {
   public StreamRequest<MuteResponse> mute(MuteRequest request) throws StreamException {
 
     return new StreamRequest<MuteResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/moderation/mute",
         request,
@@ -646,9 +576,7 @@ public class ModerationImpl {
       throws StreamException {
 
     return new StreamRequest<ListQueuesResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/moderation/queues",
         request,
@@ -666,9 +594,7 @@ public class ModerationImpl {
       throws StreamException {
 
     return new StreamRequest<QueueResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/moderation/queues",
         request,
@@ -682,9 +608,7 @@ public class ModerationImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<QueueResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/moderation/queues/{id}",
         request,
@@ -703,9 +627,7 @@ public class ModerationImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<QueueResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "PATCH",
         "/api/v2/moderation/queues/{id}",
         request,
@@ -724,9 +646,7 @@ public class ModerationImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<QueueResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/moderation/queues/{id}/delete",
         request,
@@ -744,9 +664,7 @@ public class ModerationImpl {
       throws StreamException {
 
     return new StreamRequest<QueryReviewQueueResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/moderation/review_queue",
         request,
@@ -765,9 +683,7 @@ public class ModerationImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<GetReviewQueueItemResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/moderation/review_queue/{id}",
         request,
@@ -786,9 +702,7 @@ public class ModerationImpl {
       throws StreamException {
 
     return new StreamRequest<GetSetupSessionResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/moderation/setup",
         request,
@@ -806,9 +720,7 @@ public class ModerationImpl {
       UpsertSetupSessionRequest request) throws StreamException {
 
     return new StreamRequest<UpsertSetupSessionResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/moderation/setup",
         request,
@@ -821,9 +733,7 @@ public class ModerationImpl {
       throws StreamException {
 
     return new StreamRequest<SubmitActionResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/moderation/submit_action",
         request,
@@ -836,9 +746,7 @@ public class ModerationImpl {
       SubmitModerationFeedbackRequest request) throws StreamException {
 
     return new StreamRequest<SubmitModerationFeedbackResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/moderation/submit_moderation_feedback",
         request,
@@ -850,9 +758,7 @@ public class ModerationImpl {
   public StreamRequest<UnbanResponse> unban(UnbanRequest request) throws StreamException {
 
     return new StreamRequest<UnbanResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/moderation/unban",
         request,
@@ -864,9 +770,7 @@ public class ModerationImpl {
   public StreamRequest<UnmuteResponse> unmute(UnmuteRequest request) throws StreamException {
 
     return new StreamRequest<UnmuteResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/moderation/unmute",
         request,

--- a/src/main/java/io/getstream/services/ModerationImpl.java
+++ b/src/main/java/io/getstream/services/ModerationImpl.java
@@ -565,7 +565,8 @@ public class ModerationImpl {
 
   @NotNull
   public StreamRequest<DeleteModerationRuleResponse> deleteModerationRule(
-      DeleteModerationRuleRequest request) throws StreamException {
+      @NotNull String id, DeleteModerationRuleRequest request) throws StreamException {
+    var pathParams = Map.of("id", id);
 
     return new StreamRequest<DeleteModerationRuleResponse>(
         client.getHttpClient(),
@@ -574,18 +575,20 @@ public class ModerationImpl {
         "DELETE",
         "/api/v2/moderation/moderation_rule/{id}",
         request,
-        null,
+        pathParams,
         new TypeReference<DeleteModerationRuleResponse>() {});
   }
 
   @NotNull
-  public StreamRequest<DeleteModerationRuleResponse> deleteModerationRule() throws StreamException {
-    return deleteModerationRule(new DeleteModerationRuleRequest());
+  public StreamRequest<DeleteModerationRuleResponse> deleteModerationRule(@NotNull String id)
+      throws StreamException {
+    return deleteModerationRule(id, new DeleteModerationRuleRequest());
   }
 
   @NotNull
   public StreamRequest<GetModerationRuleResponse> getModerationRule(
-      GetModerationRuleRequest request) throws StreamException {
+      @NotNull String id, GetModerationRuleRequest request) throws StreamException {
+    var pathParams = Map.of("id", id);
 
     return new StreamRequest<GetModerationRuleResponse>(
         client.getHttpClient(),
@@ -594,13 +597,14 @@ public class ModerationImpl {
         "GET",
         "/api/v2/moderation/moderation_rule/{id}",
         request,
-        null,
+        pathParams,
         new TypeReference<GetModerationRuleResponse>() {});
   }
 
   @NotNull
-  public StreamRequest<GetModerationRuleResponse> getModerationRule() throws StreamException {
-    return getModerationRule(new GetModerationRuleRequest());
+  public StreamRequest<GetModerationRuleResponse> getModerationRule(@NotNull String id)
+      throws StreamException {
+    return getModerationRule(id, new GetModerationRuleRequest());
   }
 
   @NotNull

--- a/src/main/java/io/getstream/services/VideoImpl.java
+++ b/src/main/java/io/getstream/services/VideoImpl.java
@@ -32,9 +32,7 @@ public class VideoImpl {
       GetActiveCallsStatusRequest request) throws StreamException {
 
     return new StreamRequest<GetActiveCallsStatusResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/video/active_calls_status",
         request,
@@ -52,9 +50,7 @@ public class VideoImpl {
       QueryUserFeedbackRequest request) throws StreamException {
 
     return new StreamRequest<QueryUserFeedbackResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/video/call/feedback",
         request,
@@ -72,9 +68,7 @@ public class VideoImpl {
       throws StreamException {
 
     return new StreamRequest<QueryCallMembersResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/video/call/members",
         request,
@@ -87,9 +81,7 @@ public class VideoImpl {
       throws StreamException {
 
     return new StreamRequest<QueryCallStatsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/video/call/stats",
         request,
@@ -111,9 +103,7 @@ public class VideoImpl {
             "id", id);
 
     return new StreamRequest<GetCallResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/video/call/{type}/{id}",
         request,
@@ -136,9 +126,7 @@ public class VideoImpl {
             "id", id);
 
     return new StreamRequest<UpdateCallResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "PATCH",
         "/api/v2/video/call/{type}/{id}",
         request,
@@ -162,9 +150,7 @@ public class VideoImpl {
             "id", id);
 
     return new StreamRequest<GetOrCreateCallResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/video/call/{type}/{id}",
         request,
@@ -187,9 +173,7 @@ public class VideoImpl {
             "id", id);
 
     return new StreamRequest<BlockUserResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/video/call/{type}/{id}/block",
         request,
@@ -207,9 +191,7 @@ public class VideoImpl {
             "id", id);
 
     return new StreamRequest<SendClosedCaptionResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/video/call/{type}/{id}/closed_captions",
         request,
@@ -226,9 +208,7 @@ public class VideoImpl {
             "id", id);
 
     return new StreamRequest<DeleteCallResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/video/call/{type}/{id}/delete",
         request,
@@ -252,9 +232,7 @@ public class VideoImpl {
             "id", id);
 
     return new StreamRequest<SendCallEventResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/video/call/{type}/{id}/event",
         request,
@@ -278,9 +256,7 @@ public class VideoImpl {
             "id", id);
 
     return new StreamRequest<CollectUserFeedbackResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/video/call/{type}/{id}/feedback",
         request,
@@ -297,9 +273,7 @@ public class VideoImpl {
             "id", id);
 
     return new StreamRequest<GoLiveResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/video/call/{type}/{id}/go_live",
         request,
@@ -322,9 +296,7 @@ public class VideoImpl {
             "id", id);
 
     return new StreamRequest<KickUserResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/video/call/{type}/{id}/kick",
         request,
@@ -341,9 +313,7 @@ public class VideoImpl {
             "id", id);
 
     return new StreamRequest<EndCallResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/video/call/{type}/{id}/mark_ended",
         request,
@@ -367,9 +337,7 @@ public class VideoImpl {
             "id", id);
 
     return new StreamRequest<UpdateCallMembersResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/video/call/{type}/{id}/members",
         request,
@@ -392,9 +360,7 @@ public class VideoImpl {
             "id", id);
 
     return new StreamRequest<MuteUsersResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/video/call/{type}/{id}/mute_users",
         request,
@@ -418,9 +384,7 @@ public class VideoImpl {
             "type", type);
 
     return new StreamRequest<QueryCallParticipantsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/video/call/{type}/{id}/participants",
         request,
@@ -443,9 +407,7 @@ public class VideoImpl {
             "id", id);
 
     return new StreamRequest<PinResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/video/call/{type}/{id}/pin",
         request,
@@ -463,9 +425,7 @@ public class VideoImpl {
             "id", id);
 
     return new StreamRequest<ListRecordingsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/video/call/{type}/{id}/recordings",
         request,
@@ -493,9 +453,7 @@ public class VideoImpl {
             "recording_type", recordingType);
 
     return new StreamRequest<StartRecordingResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/video/call/{type}/{id}/recordings/{recording_type}/start",
         request,
@@ -524,9 +482,7 @@ public class VideoImpl {
             "recording_type", recordingType);
 
     return new StreamRequest<StopRecordingResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/video/call/{type}/{id}/recordings/{recording_type}/stop",
         request,
@@ -551,9 +507,7 @@ public class VideoImpl {
             "id", id);
 
     return new StreamRequest<GetCallReportResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/video/call/{type}/{id}/report",
         request,
@@ -576,9 +530,7 @@ public class VideoImpl {
             "id", id);
 
     return new StreamRequest<RingCallResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/video/call/{type}/{id}/ring",
         request,
@@ -602,9 +554,7 @@ public class VideoImpl {
             "id", id);
 
     return new StreamRequest<StartRTMPBroadcastsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/video/call/{type}/{id}/rtmp_broadcasts",
         request,
@@ -622,9 +572,7 @@ public class VideoImpl {
             "id", id);
 
     return new StreamRequest<StopAllRTMPBroadcastsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/video/call/{type}/{id}/rtmp_broadcasts/stop",
         request,
@@ -652,9 +600,7 @@ public class VideoImpl {
             "name", name);
 
     return new StreamRequest<StopRTMPBroadcastsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/video/call/{type}/{id}/rtmp_broadcasts/{name}/stop",
         request,
@@ -686,9 +632,7 @@ public class VideoImpl {
             "user_session", userSession);
 
     return new StreamRequest<GetCallParticipantSessionMetricsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/video/call/{type}/{id}/session/{session}/participant/{user}/{user_session}/details/track",
         request,
@@ -722,9 +666,7 @@ public class VideoImpl {
             "session", session);
 
     return new StreamRequest<QueryCallParticipantSessionsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/video/call/{type}/{id}/session/{session}/participant_sessions",
         request,
@@ -749,9 +691,7 @@ public class VideoImpl {
             "id", id);
 
     return new StreamRequest<StartHLSBroadcastingResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/video/call/{type}/{id}/start_broadcasting",
         request,
@@ -775,9 +715,7 @@ public class VideoImpl {
             "id", id);
 
     return new StreamRequest<StartClosedCaptionsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/video/call/{type}/{id}/start_closed_captions",
         request,
@@ -801,9 +739,7 @@ public class VideoImpl {
             "id", id);
 
     return new StreamRequest<StartFrameRecordingResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/video/call/{type}/{id}/start_frame_recording",
         request,
@@ -827,9 +763,7 @@ public class VideoImpl {
             "id", id);
 
     return new StreamRequest<StartTranscriptionResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/video/call/{type}/{id}/start_transcription",
         request,
@@ -853,9 +787,7 @@ public class VideoImpl {
             "id", id);
 
     return new StreamRequest<StopHLSBroadcastingResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/video/call/{type}/{id}/stop_broadcasting",
         request,
@@ -879,9 +811,7 @@ public class VideoImpl {
             "id", id);
 
     return new StreamRequest<StopClosedCaptionsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/video/call/{type}/{id}/stop_closed_captions",
         request,
@@ -905,9 +835,7 @@ public class VideoImpl {
             "id", id);
 
     return new StreamRequest<StopFrameRecordingResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/video/call/{type}/{id}/stop_frame_recording",
         request,
@@ -930,9 +858,7 @@ public class VideoImpl {
             "id", id);
 
     return new StreamRequest<StopLiveResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/video/call/{type}/{id}/stop_live",
         request,
@@ -956,9 +882,7 @@ public class VideoImpl {
             "id", id);
 
     return new StreamRequest<StopTranscriptionResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/video/call/{type}/{id}/stop_transcription",
         request,
@@ -982,9 +906,7 @@ public class VideoImpl {
             "id", id);
 
     return new StreamRequest<ListTranscriptionsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/video/call/{type}/{id}/transcriptions",
         request,
@@ -1007,9 +929,7 @@ public class VideoImpl {
             "id", id);
 
     return new StreamRequest<UnblockUserResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/video/call/{type}/{id}/unblock",
         request,
@@ -1026,9 +946,7 @@ public class VideoImpl {
             "id", id);
 
     return new StreamRequest<UnpinResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/video/call/{type}/{id}/unpin",
         request,
@@ -1046,9 +964,7 @@ public class VideoImpl {
             "id", id);
 
     return new StreamRequest<UpdateUserPermissionsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/video/call/{type}/{id}/user_permissions",
         request,
@@ -1072,9 +988,7 @@ public class VideoImpl {
             "filename", filename);
 
     return new StreamRequest<DeleteRecordingResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "DELETE",
         "/api/v2/video/call/{type}/{id}/{session}/recordings/{filename}",
         request,
@@ -1105,9 +1019,7 @@ public class VideoImpl {
             "filename", filename);
 
     return new StreamRequest<DeleteTranscriptionResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "DELETE",
         "/api/v2/video/call/{type}/{id}/{session}/transcriptions/{filename}",
         request,
@@ -1127,9 +1039,7 @@ public class VideoImpl {
       ReportClientCallEventRequest request) throws StreamException {
 
     return new StreamRequest<ReportClientEventResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/video/call_client_event",
         request,
@@ -1142,9 +1052,7 @@ public class VideoImpl {
       QueryCallSessionStatsRequest request) throws StreamException {
 
     return new StreamRequest<QueryCallSessionStatsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/video/call_stats",
         request,
@@ -1172,9 +1080,7 @@ public class VideoImpl {
             "session", session);
 
     return new StreamRequest<QueryCallStatsMapResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/video/call_stats/{call_type}/{call_id}/{session}/map",
         request,
@@ -1208,9 +1114,7 @@ public class VideoImpl {
             "user_session", userSession);
 
     return new StreamRequest<GetCallSessionParticipantStatsDetailsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/video/call_stats/{call_type}/{call_id}/{session}/participant/{user}/{user_session}/details",
         request,
@@ -1250,9 +1154,7 @@ public class VideoImpl {
             "session", session);
 
     return new StreamRequest<QueryCallSessionParticipantStatsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/video/call_stats/{call_type}/{call_id}/{session}/participants",
         request,
@@ -1287,9 +1189,7 @@ public class VideoImpl {
             "user_session", userSession);
 
     return new StreamRequest<QueryCallSessionParticipantStatsTimelineResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/video/call_stats/{call_type}/{call_id}/{session}/participants/{user}/{user_session}/timeline",
         request,
@@ -1320,9 +1220,7 @@ public class VideoImpl {
       throws StreamException {
 
     return new StreamRequest<QueryCallsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/video/calls",
         request,
@@ -1340,9 +1238,7 @@ public class VideoImpl {
       throws StreamException {
 
     return new StreamRequest<ListCallTypeResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/video/calltypes",
         request,
@@ -1360,9 +1256,7 @@ public class VideoImpl {
       throws StreamException {
 
     return new StreamRequest<CreateCallTypeResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/video/calltypes",
         request,
@@ -1376,9 +1270,7 @@ public class VideoImpl {
     var pathParams = Map.of("name", name);
 
     return new StreamRequest<Response>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "DELETE",
         "/api/v2/video/calltypes/{name}",
         request,
@@ -1397,9 +1289,7 @@ public class VideoImpl {
     var pathParams = Map.of("name", name);
 
     return new StreamRequest<GetCallTypeResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/video/calltypes/{name}",
         request,
@@ -1419,9 +1309,7 @@ public class VideoImpl {
     var pathParams = Map.of("name", name);
 
     return new StreamRequest<UpdateCallTypeResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "PUT",
         "/api/v2/video/calltypes/{name}",
         request,
@@ -1439,9 +1327,7 @@ public class VideoImpl {
   public StreamRequest<GetEdgesResponse> getEdges(GetEdgesRequest request) throws StreamException {
 
     return new StreamRequest<GetEdgesResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/video/edges",
         request,
@@ -1459,9 +1345,7 @@ public class VideoImpl {
       throws StreamException {
 
     return new StreamRequest<ResolveSipAuthResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/video/sip/auth",
         request,
@@ -1474,9 +1358,7 @@ public class VideoImpl {
       ListSIPInboundRoutingRuleRequest request) throws StreamException {
 
     return new StreamRequest<ListSIPInboundRoutingRuleResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/video/sip/inbound_routing_rules",
         request,
@@ -1495,9 +1377,7 @@ public class VideoImpl {
       CreateSIPInboundRoutingRuleRequest request) throws StreamException {
 
     return new StreamRequest<SIPInboundRoutingRuleResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/video/sip/inbound_routing_rules",
         request,
@@ -1511,9 +1391,7 @@ public class VideoImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<DeleteSIPInboundRoutingRuleResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "DELETE",
         "/api/v2/video/sip/inbound_routing_rules/{id}",
         request,
@@ -1533,9 +1411,7 @@ public class VideoImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<UpdateSIPInboundRoutingRuleResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "PUT",
         "/api/v2/video/sip/inbound_routing_rules/{id}",
         request,
@@ -1548,9 +1424,7 @@ public class VideoImpl {
       throws StreamException {
 
     return new StreamRequest<ListSIPTrunksResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "GET",
         "/api/v2/video/sip/inbound_trunks",
         request,
@@ -1568,9 +1442,7 @@ public class VideoImpl {
       throws StreamException {
 
     return new StreamRequest<CreateSIPTrunkResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/video/sip/inbound_trunks",
         request,
@@ -1584,9 +1456,7 @@ public class VideoImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<DeleteSIPTrunkResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "DELETE",
         "/api/v2/video/sip/inbound_trunks/{id}",
         request,
@@ -1606,9 +1476,7 @@ public class VideoImpl {
     var pathParams = Map.of("id", id);
 
     return new StreamRequest<UpdateSIPTrunkResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "PUT",
         "/api/v2/video/sip/inbound_trunks/{id}",
         request,
@@ -1621,9 +1489,7 @@ public class VideoImpl {
       ResolveSipInboundRequest request) throws StreamException {
 
     return new StreamRequest<ResolveSipInboundResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/video/sip/resolve",
         request,
@@ -1636,9 +1502,7 @@ public class VideoImpl {
       QueryAggregateCallStatsRequest request) throws StreamException {
 
     return new StreamRequest<QueryAggregateCallStatsResponse>(
-        client.getHttpClient(),
-        client.getObjectMapper(),
-        client.getBaseUrl(),
+        client,
         "POST",
         "/api/v2/video/stats",
         request,


### PR DESCRIPTION
## Ticket
https://linear.app/stream/issue/CHA-2957/logging

## Summary
Regenerates the Java SDK against chat master and wires the CHA-2957 structured logging through the generated service clients. Two commits, reviewable separately:

1. `chore: sync generated client to chat master API` — pure regen against current chat master. Removes the 4 external-storage importer endpoints (`/imports/v2/external-storage` get/upsert/delete/validate) that [CHA-3889] / #14776 gated as private/operator-only and hid from the public OpenAPI spec (`Ignore: true`; still routed but behind the `external_storage_import` feature flag). Adds `importBlockList`. Adds an `id` path param to `getModerationRule`/`deleteModerationRule`. Refreshes assorted model fields. No behavior change: the generated Impls still use the existing `StreamRequest` constructor.
2. `feat: wire structured logging through the generated service clients` — regenerated with the updated Java template so the generated `*Impl` clients construct `StreamRequest` with the `StreamHTTPClient`. This lets the client-level SLF4J logger reach the request layer, so the CHA-2957 logging events fire on real API calls (they were framework-only before this).

## Notes for review
- The importer-endpoint removals are the intended [CHA-3889] de-publication, not a customer-facing break: those endpoints were beta + operator-only and hidden from the public spec, and callers hit `NotAllowed` without the feature flag regardless.
- Does not auto-release: the Java SDK only releases via the `release-*` branch flow. Publish later via the manual Release workflow when ready.
