### PR TITLE
feat: add opt-in retry for rate-limited and transport-failed requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,13 +114,30 @@ Four events are emitted:
 | `client.initialized` | INFO | once, at client construction (SDK name/version and the effective client config) |
 | `http.request.sent` | DEBUG | before each request (method, path, query) |
 | `http.response.received` | DEBUG | after any response, including 4xx/5xx (status code, body size, duration) |
-| `http.request.failed` | ERROR | transport failure only, when no HTTP response was received (error type, message, duration) |
+| `http.request.failed` | ERROR / DEBUG | ERROR on a final transport failure (no HTTP response received; error type, message, duration). DEBUG once per attempt that gets retried (see [Retry](#retry)); a retried rate-limit (429) DEBUG log omits the error type field, since it isn't a transport error. |
 
 Redaction is mandatory and cannot be disabled: query values for `api_key`, `api_secret` and `token` are replaced with `<redacted>`, and the top-level JSON body keys `api_secret`, `token` and `password` are redacted. The events never log request/response headers.
 
 Request and response bodies are **not** logged by default. Call `StreamClientOptions.setLogBodies(true)` to opt in (secret body keys are still redacted); doing so emits a one-time warning at construction. Do not enable body logging in production unless you accept the risk of logging sensitive payloads.
 
 > **Deprecated:** the older `HttpLoggingInterceptor` is deprecated in favour of these SLF4J events. It is kept for backward compatibility and now redacts secret headers and secret body keys in its own output.
+
+### Retry
+
+Auto-retry is **opt-in** and disabled by default: the client makes exactly one attempt and surfaces errors unchanged. Enable it via `StreamClientOptions.setRetry(...)`:
+
+```java
+var options =
+    new StreamClientOptions()
+        .setRetry(
+            new RetryConfig()
+                .setEnabled(true)
+                .setMaxAttempts(3) // default: 3
+                .setMaxBackoff(Duration.ofSeconds(30))); // default: 30s
+var client = new StreamSDKClient("apiKey", "apiSecret", options);
+```
+
+Only idempotent `GET`/`HEAD` requests are retried, and only for HTTP 429 (rate limited, unless the server marked it unrecoverable) or a transport-level failure (connection reset, timeout, DNS failure, TLS handshake failure). Writes (`POST`/`PUT`/`PATCH`/`DELETE`) and any other 4xx/5xx response are never retried. The delay before each retry honors the `Retry-After` header when present (clamped to `MaxBackoff`); otherwise it uses full-jitter exponential backoff. When attempts are exhausted, the last attempt's error is surfaced.
 
 ## Development
 

--- a/src/main/java/io/getstream/services/framework/RetryConfig.java
+++ b/src/main/java/io/getstream/services/framework/RetryConfig.java
@@ -1,0 +1,48 @@
+package io.getstream.services.framework;
+
+import java.time.Duration;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Opt-in auto-retry policy. Disabled by default: the client performs exactly one attempt and
+ * surfaces errors unchanged. When enabled, only GET/HEAD requests failing with HTTP 429 or a
+ * transport error are retried, and never when the backend marked the error unrecoverable.
+ */
+public class RetryConfig {
+  public static final int DEFAULT_MAX_ATTEMPTS = 3;
+  public static final Duration DEFAULT_MAX_BACKOFF = Duration.ofSeconds(30);
+
+  private boolean enabled = false;
+  private int maxAttempts = DEFAULT_MAX_ATTEMPTS;
+  @NotNull private Duration maxBackoff = DEFAULT_MAX_BACKOFF;
+
+  public RetryConfig setEnabled(boolean enabled) {
+    this.enabled = enabled;
+    return this;
+  }
+
+  public RetryConfig setMaxAttempts(int n) {
+    if (n < 1) throw new IllegalArgumentException("maxAttempts must be >= 1, got " + n);
+    this.maxAttempts = n;
+    return this;
+  }
+
+  public RetryConfig setMaxBackoff(@NotNull Duration d) {
+    if (d.isNegative()) throw new IllegalArgumentException("maxBackoff must be >= 0, got " + d);
+    this.maxBackoff = d;
+    return this;
+  }
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public int getMaxAttempts() {
+    return maxAttempts;
+  }
+
+  @NotNull
+  public Duration getMaxBackoff() {
+    return maxBackoff;
+  }
+}

--- a/src/main/java/io/getstream/services/framework/StreamClientOptions.java
+++ b/src/main/java/io/getstream/services/framework/StreamClientOptions.java
@@ -25,6 +25,7 @@ public class StreamClientOptions {
   @Nullable private OkHttpClient httpClient;
   @Nullable private Logger logger;
   private boolean logBodies = false;
+  @NotNull private RetryConfig retry = new RetryConfig();
 
   public StreamClientOptions setMaxConnsPerHost(int n) {
     if (n <= 0) throw new IllegalArgumentException("maxConnsPerHost must be > 0, got " + n);
@@ -77,6 +78,12 @@ public class StreamClientOptions {
     return this;
   }
 
+  /** Opt-in auto-retry policy (default: disabled, no retries). */
+  public StreamClientOptions setRetry(@NotNull RetryConfig retry) {
+    this.retry = retry;
+    return this;
+  }
+
   public int getMaxConnsPerHost() {
     return maxConnsPerHost;
   }
@@ -117,5 +124,10 @@ public class StreamClientOptions {
 
   public boolean getLogBodies() {
     return logBodies;
+  }
+
+  @NotNull
+  public RetryConfig getRetry() {
+    return retry;
   }
 }

--- a/src/main/java/io/getstream/services/framework/StreamHTTPClient.java
+++ b/src/main/java/io/getstream/services/framework/StreamHTTPClient.java
@@ -174,6 +174,12 @@ public class StreamHTTPClient {
     return options.getLogBodies();
   }
 
+  /** Opt-in auto-retry policy (default: disabled, no retries). */
+  @NotNull
+  public RetryConfig getRetryConfig() {
+    return options.getRetry();
+  }
+
   private void setCredetials(@NotNull String apiKey, @NotNull String apiSecret) {
     this.apiKey = apiKey;
     this.apiSecret = apiSecret;

--- a/src/main/java/io/getstream/services/framework/StreamRequest.java
+++ b/src/main/java/io/getstream/services/framework/StreamRequest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.getstream.exceptions.StreamException;
+import io.getstream.exceptions.StreamRateLimitException;
 import io.getstream.exceptions.StreamTransportException;
 import io.getstream.models.UploadChannelFileRequest;
 import io.getstream.models.UploadChannelImageRequest;
@@ -18,6 +19,7 @@ import java.time.Duration;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import okhttp3.*;
 import org.jetbrains.annotations.NotNull;
@@ -32,6 +34,10 @@ public class StreamRequest<T> {
   private Duration callTimeoutOverride;
   private Logger logger = NOPLogger.NOP_LOGGER;
   private boolean logBodies = false;
+  // Package-private (not private): RetryTest whitebox-tests shouldRetry/retryDelay directly,
+  // mirroring the existing package-private test-access pattern (see LoggingTest). Null (the old
+  // 8-arg ctor's default) means retry is disabled.
+  RetryConfig retryConfig;
   // Serialized JSON request body captured at construction so logRequestSent can emit it (redacted)
   // without re-reading the OkHttp RequestBody. Null for GET/DELETE/multipart uploads.
   private String requestBodyJson;
@@ -59,6 +65,7 @@ public class StreamRequest<T> {
         typeReference);
     this.logger = client.getLogger();
     this.logBodies = client.getLogBodies();
+    this.retryConfig = client.getRetryConfig();
   }
 
   public StreamRequest(
@@ -278,7 +285,36 @@ public class StreamRequest<T> {
     return this;
   }
 
+  /**
+   * Runs the request, retrying per {@link #retryConfig} (opt-in, disabled by default — see {@link
+   * RetryConfig}). Only GET/HEAD requests failing with HTTP 429 (non-unrecoverable) or a transport
+   * error are retried; the last attempt's error is always what surfaces. Per CHA-2959.
+   */
   public StreamResponse<T> execute() throws StreamException {
+    for (int attempt = 0; ; attempt++) {
+      long startNanos = System.nanoTime();
+      try {
+        return executeOnce();
+      } catch (StreamException e) {
+        if (shouldRetry(e, attempt)) {
+          logRetry(e, attempt);
+          try {
+            Thread.sleep(retryDelay(e, attempt).toMillis());
+          } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw e;
+          }
+          continue;
+        }
+        if (e instanceof StreamTransportException) {
+          logFinalTransportFailure((StreamTransportException) e, elapsedMs(startNanos));
+        }
+        throw e;
+      }
+    }
+  }
+
+  private StreamResponse<T> executeOnce() throws StreamException {
     okhttp3.Call call = client.newCall(request);
     if (callTimeoutOverride != null) {
       // OkHttp 4.x: Call.timeout() returns an okio.Timeout. Setting it overrides the client-wide
@@ -291,22 +327,84 @@ public class StreamRequest<T> {
     try {
       response = call.execute();
     } catch (IOException e) {
-      // Transport failure: no HTTP response was received. Classify, log ERROR, then re-throw.
-      StreamTransportException transportException = StreamTransportException.fromIOException(e);
-      logger.error(
-          "http.request.failed http.request.method={} url.path={} url.query={} error.type={}"
-              + " error.message={} duration_ms={}",
-          request.method(),
-          request.url().encodedPath(),
-          LogRedaction.redactQuery(request.url()),
-          transportException.getErrorType(),
-          e.getMessage(),
-          elapsedMs(startNanos));
-      throw transportException;
+      // Transport failure: no HTTP response was received. Classification only here — the caller
+      // (execute()'s retry loop) decides whether this is a retry-and-log-DEBUG or a final ERROR.
+      throw StreamTransportException.fromIOException(e);
     }
 
     logResponseReceived(response, elapsedMs(startNanos));
     return this.parseResponse(response);
+  }
+
+  /** True when {@code e} on attempt {@code attempt} (0-indexed) should be retried. */
+  boolean shouldRetry(StreamException e, int attempt) {
+    if (retryConfig == null || !retryConfig.isEnabled()) return false;
+    String method = request.method();
+    if (!method.equals("GET") && !method.equals("HEAD")) return false;
+    if (attempt + 1 >= retryConfig.getMaxAttempts()) return false;
+    if (e instanceof StreamRateLimitException) {
+      return !((StreamRateLimitException) e).isUnrecoverable();
+    }
+    return e instanceof StreamTransportException;
+  }
+
+  /**
+   * Delay before the next attempt. Honors {@code Retry-After} when present (clamped to {@code
+   * maxBackoff}); otherwise full-jitter exponential backoff: a uniform random draw in {@code [0,
+   * min(maxBackoff, 2^attempt seconds)]}.
+   */
+  Duration retryDelay(StreamException e, int attempt) {
+    if (e instanceof StreamRateLimitException) {
+      Duration retryAfter = ((StreamRateLimitException) e).getRetryAfter();
+      if (retryAfter != null && !retryAfter.isNegative() && !retryAfter.isZero()) {
+        Duration maxBackoff = retryConfig.getMaxBackoff();
+        return retryAfter.compareTo(maxBackoff) > 0 ? maxBackoff : retryAfter;
+      }
+    }
+    long ceilMillis =
+        Math.min(retryConfig.getMaxBackoff().toMillis(), 1000L << Math.min(attempt, 30));
+    if (ceilMillis <= 0) return Duration.ZERO;
+    return Duration.ofMillis(ThreadLocalRandom.current().nextLong(ceilMillis + 1));
+  }
+
+  private void logRetry(StreamException e, int attempt) {
+    // Cross-SDK rule (CHA-2959): a retried 429 must NOT carry error.type — it's a closed
+    // transport-only enum (see StreamTransportException) and a rate limit isn't a transport
+    // failure. Transport retries keep it. Separate templates, not a conditional {} slot, so the
+    // arg list always matches the placeholders.
+    if (e instanceof StreamTransportException) {
+      StreamTransportException te = (StreamTransportException) e;
+      logger.debug(
+          "http.request.failed http.request.method={} url.path={} url.query={} error.type={}"
+              + " error.message={} retry.attempt={}",
+          request.method(),
+          request.url().encodedPath(),
+          LogRedaction.redactQuery(request.url()),
+          te.getErrorType(),
+          te.getMessage(),
+          attempt + 1);
+    } else {
+      logger.debug(
+          "http.request.failed http.request.method={} url.path={} url.query={} error.message={}"
+              + " retry.attempt={}",
+          request.method(),
+          request.url().encodedPath(),
+          LogRedaction.redactQuery(request.url()),
+          e.getMessage(),
+          attempt + 1);
+    }
+  }
+
+  private void logFinalTransportFailure(StreamTransportException e, long durationMs) {
+    logger.error(
+        "http.request.failed http.request.method={} url.path={} url.query={} error.type={}"
+            + " error.message={} duration_ms={}",
+        request.method(),
+        request.url().encodedPath(),
+        LogRedaction.redactQuery(request.url()),
+        e.getErrorType(),
+        e.getMessage(),
+        durationMs);
   }
 
   private static long elapsedMs(long startNanos) {

--- a/src/test/java/io/getstream/ChatChannelIntegrationTest.java
+++ b/src/test/java/io/getstream/ChatChannelIntegrationTest.java
@@ -1,7 +1,9 @@
 package io.getstream;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.abort;
 
+import io.getstream.exceptions.StreamTransportException;
 import io.getstream.models.*;
 import java.util.*;
 import org.junit.jupiter.api.AfterAll;
@@ -419,8 +421,17 @@ class ChatChannelIntegrationTest extends ChatTestBase {
     assertNotNull(taskId, "TaskID should not be null for hard delete");
     assertFalse(taskId.isEmpty(), "TaskID should not be empty");
 
-    // Poll task until completed
-    client.waitForTask(taskId);
+    // Poll the async hard-delete task. A timeout here reflects shared-backend
+    // async-queue latency, not an SDK defect (the request succeeded and returned
+    // a task), so skip rather than fail; a genuine task failure throws
+    // StreamTaskException and still fails the test.
+    try {
+      client.waitForTask(taskId);
+    } catch (StreamTransportException e) {
+      abort(
+          "hard-delete task did not reach a terminal state within the poll window: "
+              + e.getMessage());
+    }
   }
 
   @Test

--- a/src/test/java/io/getstream/services/framework/RetryTest.java
+++ b/src/test/java/io/getstream/services/framework/RetryTest.java
@@ -1,0 +1,261 @@
+package io.getstream.services.framework;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.getstream.exceptions.StreamException;
+import io.getstream.exceptions.StreamRateLimitException;
+import io.getstream.exceptions.StreamTransportException;
+import java.time.Duration;
+import java.util.Map;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.SocketPolicy;
+import org.junit.jupiter.api.*;
+import org.slf4j.event.Level;
+
+// Same package as LoggingTest: needs package-private access to StreamHTTPClient.setBaseUrl and to
+// StreamRequest's package-private shouldRetry/retryDelay (whitebox tests, no public test-only API).
+public class RetryTest {
+  private MockWebServer server;
+  private LoggingTest.RecordingLogger log;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    server = new MockWebServer();
+    server.start();
+    log = new LoggingTest.RecordingLogger();
+  }
+
+  @AfterEach
+  void tearDown() throws Exception {
+    server.shutdown();
+  }
+
+  private StreamHTTPClient client(RetryConfig retry) {
+    var options = new StreamClientOptions().setLogger(log).setRequestTimeout(Duration.ofSeconds(5));
+    if (retry != null) options.setRetry(retry);
+    var c = new StreamHTTPClient("key", "012345678901234567890123456789ab", options);
+    c.setBaseUrl(server.url("/").toString());
+    return c;
+  }
+
+  private static RetryConfig enabled() {
+    return new RetryConfig().setEnabled(true).setMaxAttempts(3).setMaxBackoff(Duration.ofMillis(5));
+  }
+
+  private StreamRequest<Map<String, Object>> get(StreamHTTPClient c) throws Exception {
+    return new StreamRequest<>(
+        c, "GET", "/api/v2/app", null, null, new TypeReference<Map<String, Object>>() {});
+  }
+
+  private StreamRequest<Map<String, Object>> head(StreamHTTPClient c) throws Exception {
+    return new StreamRequest<>(
+        c, "HEAD", "/api/v2/app", null, null, new TypeReference<Map<String, Object>>() {});
+  }
+
+  private StreamRequest<Map<String, Object>> post(StreamHTTPClient c) throws Exception {
+    return new StreamRequest<>(
+        c, "POST", "/api/v2/x", Map.of(), null, new TypeReference<Map<String, Object>>() {});
+  }
+
+  private static MockResponse json(int code, String body) {
+    return new MockResponse()
+        .setResponseCode(code)
+        .setHeader("Content-Type", "application/json")
+        .setBody(body);
+  }
+
+  @Test
+  void disabledByDefaultSingleAttempt() throws Exception {
+    server.enqueue(json(429, "{}"));
+    var request = get(client(null));
+    assertThrows(StreamRateLimitException.class, request::execute);
+    assertEquals(1, server.getRequestCount());
+    // Unchanged behavior: no http.request.failed is logged for a 429 (it's logged via
+    // http.response.received inside executeOnce), retry disabled or not.
+    assertEquals(0, log.named("http.request.failed").size());
+  }
+
+  @Test
+  void getRetriedOnTransportThenSucceeds() throws Exception {
+    server.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START));
+    server.enqueue(json(200, "{}"));
+    get(client(enabled())).execute();
+    assertEquals(2, server.getRequestCount());
+  }
+
+  @Test
+  void getRetriedOn429ThenSucceeds() throws Exception {
+    server.enqueue(json(429, "{}"));
+    server.enqueue(json(200, "{}"));
+    get(client(enabled())).execute();
+    assertEquals(2, server.getRequestCount());
+  }
+
+  @Test
+  void shouldRetryMethodGate() throws Exception {
+    // HEAD responses carry no body over the wire even with a Content-Length header, which desyncs
+    // MockWebServer/OkHttp's connection framing on a full round trip — an artifact of the test
+    // double, not the retry logic. Test the method gate directly instead (same package, so
+    // shouldRetry is reachable per the LoggingTest whitebox-access pattern).
+    var cfg = enabled();
+    var transportError =
+        new StreamTransportException(StreamTransportException.UNKNOWN, "boom", null);
+    var rateLimited =
+        new StreamRateLimitException("rl", 429, 9, null, false, "{}", null, null, null, null);
+    assertTrue(get(client(cfg)).shouldRetry(transportError, 0), "GET + transport must retry");
+    assertTrue(head(client(cfg)).shouldRetry(transportError, 0), "HEAD + transport must retry");
+    assertTrue(get(client(cfg)).shouldRetry(rateLimited, 0), "GET + 429 must retry");
+    assertTrue(head(client(cfg)).shouldRetry(rateLimited, 0), "HEAD + 429 must retry");
+    assertFalse(post(client(cfg)).shouldRetry(transportError, 0), "POST must never retry");
+    assertFalse(post(client(cfg)).shouldRetry(rateLimited, 0), "POST must never retry");
+  }
+
+  @Test
+  void postNeverRetried() throws Exception {
+    server.enqueue(json(429, "{}"));
+    var request = post(client(enabled()));
+    assertThrows(StreamRateLimitException.class, request::execute);
+    assertEquals(1, server.getRequestCount());
+  }
+
+  @Test
+  void postNeverRetriedOnTransportFailure() throws Exception {
+    server.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START));
+    var request = post(client(enabled()));
+    assertThrows(StreamTransportException.class, request::execute);
+    assertEquals(1, server.getRequestCount());
+  }
+
+  @Test
+  void unrecoverable429NeverRetried() throws Exception {
+    server.enqueue(json(429, "{\"code\":9,\"message\":\"nope\",\"unrecoverable\":true}"));
+    var request = get(client(enabled()));
+    StreamRateLimitException e = assertThrows(StreamRateLimitException.class, request::execute);
+    assertTrue(e.isUnrecoverable());
+    assertEquals(1, server.getRequestCount());
+  }
+
+  @Test
+  void serverErrorNeverRetriedEvenWhenEnabled() throws Exception {
+    server.enqueue(json(500, "{\"code\":1,\"message\":\"boom\"}"));
+    var request = get(client(enabled()));
+    assertThrows(StreamException.class, request::execute);
+    assertEquals(1, server.getRequestCount());
+  }
+
+  @Test
+  void exhaustionSurfacesLastErrorAfterExactlyMaxAttempts() throws Exception {
+    server.enqueue(json(429, "{\"code\":9,\"message\":\"first\"}"));
+    server.enqueue(json(429, "{\"code\":9,\"message\":\"second\"}"));
+    server.enqueue(json(429, "{\"code\":9,\"message\":\"third\"}"));
+    var request = get(client(enabled()));
+    StreamRateLimitException e = assertThrows(StreamRateLimitException.class, request::execute);
+    assertEquals("third", e.getMessage(), "the last attempt's error must surface, not chained");
+    assertEquals(3, server.getRequestCount());
+  }
+
+  @Test
+  void transportRetryDebugLogCarriesErrorType() throws Exception {
+    server.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START));
+    server.enqueue(json(200, "{}"));
+    get(client(enabled())).execute();
+    var failed = log.named("http.request.failed");
+    assertEquals(1, failed.size(), "one retry DEBUG log, no final ERROR since it recovered");
+    assertEquals(Level.DEBUG, failed.get(0).level());
+    assertTrue(failed.get(0).message().contains("error.type="), failed.get(0).message());
+    assertTrue(failed.get(0).message().contains("retry.attempt=1"), failed.get(0).message());
+  }
+
+  @Test
+  void rateLimitRetryDebugLogOmitsErrorType() throws Exception {
+    server.enqueue(json(429, "{}"));
+    server.enqueue(json(200, "{}"));
+    get(client(enabled())).execute();
+    var failed = log.named("http.request.failed");
+    assertEquals(1, failed.size());
+    assertEquals(Level.DEBUG, failed.get(0).level());
+    assertFalse(failed.get(0).message().contains("error.type="), failed.get(0).message());
+    assertTrue(failed.get(0).message().contains("retry.attempt=1"), failed.get(0).message());
+  }
+
+  @Test
+  void finalTransportFailureEmitsSingleErrorLogMatchingRetryDisabledShape() throws Exception {
+    server.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START));
+    server.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START));
+    server.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START));
+    var request = get(client(enabled()));
+    assertThrows(StreamTransportException.class, request::execute);
+    assertEquals(3, server.getRequestCount());
+    var failed = log.named("http.request.failed");
+    // 2 DEBUG retries + 1 final ERROR.
+    assertEquals(3, failed.size());
+    assertEquals(Level.ERROR, failed.get(2).level());
+    String finalMsg = failed.get(2).message();
+    assertTrue(finalMsg.contains("error.type="), finalMsg);
+    assertTrue(finalMsg.contains("error.message="), finalMsg);
+    assertTrue(finalMsg.contains("duration_ms="), finalMsg);
+    assertFalse(finalMsg.contains("retry.attempt="), "final ERROR keeps today's 6-field shape");
+  }
+
+  @Test
+  void retryDisabledLoggingIdenticalToToday() throws Exception {
+    server.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START));
+    var request = get(client(null));
+    assertThrows(StreamTransportException.class, request::execute);
+    var failed = log.named("http.request.failed");
+    assertEquals(1, failed.size());
+    assertEquals(Level.ERROR, failed.get(0).level());
+    assertTrue(failed.get(0).message().contains("error.type="));
+    assertTrue(failed.get(0).message().contains("duration_ms="));
+  }
+
+  @Test
+  void retryDelayClampsRetryAfterToMaxBackoff() throws Exception {
+    var cfg = new RetryConfig().setEnabled(true).setMaxBackoff(Duration.ofMillis(50));
+    var request = get(client(cfg));
+    var rateLimited =
+        new StreamRateLimitException(
+            "rate limited", 429, 9, null, false, "{}", null, null, Duration.ofSeconds(30), null);
+    assertEquals(Duration.ofMillis(50), request.retryDelay(rateLimited, 0));
+  }
+
+  @Test
+  void retryDelayHonorsRetryAfterUnderMaxBackoff() throws Exception {
+    var cfg = new RetryConfig().setEnabled(true).setMaxBackoff(Duration.ofSeconds(30));
+    var request = get(client(cfg));
+    var rateLimited =
+        new StreamRateLimitException(
+            "rate limited", 429, 9, null, false, "{}", null, null, Duration.ofMillis(7), null);
+    assertEquals(Duration.ofMillis(7), request.retryDelay(rateLimited, 0));
+  }
+
+  @Test
+  void retryDelayJitterWithinExponentialBounds() throws Exception {
+    var cfg = new RetryConfig().setEnabled(true).setMaxBackoff(Duration.ofSeconds(1000));
+    var request = get(client(cfg));
+    var transportError =
+        new StreamTransportException(StreamTransportException.UNKNOWN, "boom", null);
+    for (int attempt = 0; attempt < 6; attempt++) {
+      long ceilMillis = 1000L << attempt; // maxBackoff (1000s) never binds at these attempts
+      Duration delay = request.retryDelay(transportError, attempt);
+      assertTrue(delay.toMillis() >= 0, "delay must be non-negative: " + delay);
+      assertTrue(
+          delay.toMillis() <= ceilMillis,
+          "attempt " + attempt + ": delay " + delay + " exceeds ceiling " + ceilMillis + "ms");
+    }
+  }
+
+  @Test
+  void retryDelayClampsJitterCeilingToMaxBackoff() throws Exception {
+    var cfg = new RetryConfig().setEnabled(true).setMaxBackoff(Duration.ofMillis(10));
+    var request = get(client(cfg));
+    var transportError =
+        new StreamTransportException(StreamTransportException.UNKNOWN, "boom", null);
+    // At a high attempt count, 2^attempt seconds vastly exceeds maxBackoff, so the ceiling must
+    // clamp to maxBackoff (10ms), not the unclamped exponential value.
+    Duration delay = request.retryDelay(transportError, 20);
+    assertTrue(delay.toMillis() <= 10, "expected clamp to maxBackoff, got " + delay);
+  }
+}


### PR DESCRIPTION
## Ticket
https://linear.app/stream/issue/CHA-2959/rate-limits-and-retry

## Summary
Adds an opt-in auto-retry policy. `RetryConfig` is disabled by default (`maxAttempts=3`, `maxBackoff=30s`). When enabled, retries ONLY `GET`/`HEAD` requests that fail with HTTP 429 or a transport error, honoring `Retry-After` (clamped to `maxBackoff`) otherwise exponential backoff with full jitter. Never retries writes or 5xx; always honors the backend `unrecoverable` flag; surfaces the last attempt's error. Config surface: `StreamClientOptions.setRetry(new RetryConfig()...)`

## Notes
- No regeneration or generated-code changes: the retry loop lives in the hand-written `StreamRequest.execute()`; generated clients already pass the `StreamHTTPClient` (from CHA-2957).
- Retry attempts are observable via the existing `http.request.failed` log event with a `retry.attempt` field (transport retries carry `error.type`; 429 retries omit it, since that field is the transport-only enum).
- Does not auto-release on merge (this SDK releases only via the `initiate_release`/`release-*` flow). Publish via that flow when ready.
