### PR TITLE
fix: name the HTTP status when the error body is not JSON

### DIFF
--- a/src/main/java/io/getstream/exceptions/StreamException.java
+++ b/src/main/java/io/getstream/exceptions/StreamException.java
@@ -106,7 +106,8 @@ public class StreamException extends Exception {
     if (parsed == null) {
       String msg =
           parseCause != null
-              ? "failed to parse error response"
+              ? String.format(
+                  "failed to parse error response: unexpected server response code %d", status)
               : String.format("Unexpected server response code %d", status);
       if (status == 429) {
         return new StreamRateLimitException(

--- a/src/test/java/io/getstream/ModerationTest.java
+++ b/src/test/java/io/getstream/ModerationTest.java
@@ -21,6 +21,10 @@ public class ModerationTest {
   static String testUserId;
   static String testUserId2;
   static String testModeratorId;
+  // The ban tests need their own target. A global ban on testUserId survives for
+  // the rest of the class, and a banned user cannot add an activity, so the
+  // activity tests failed whenever they ran after the ban.
+  static String bannedUserId;
   static String testFeedId;
   static String testActivityId;
 
@@ -34,6 +38,7 @@ public class ModerationTest {
     testUserId = "test-user-" + RandomStringUtils.randomAlphanumeric(8);
     testUserId2 = "test-user-2-" + RandomStringUtils.randomAlphanumeric(8);
     testModeratorId = "moderator-" + RandomStringUtils.randomAlphanumeric(8);
+    bannedUserId = "banned-user-" + RandomStringUtils.randomAlphanumeric(8);
 
     Map<String, UserRequest> usersMap = new HashMap<>();
     usersMap.put(
@@ -53,6 +58,13 @@ public class ModerationTest {
             .name("Moderator " + testModeratorId)
             .role("admin")
             .build());
+    usersMap.put(
+        bannedUserId,
+        UserRequest.builder()
+            .id(bannedUserId)
+            .name("Banned User " + bannedUserId)
+            .role("user")
+            .build());
 
     UpdateUsersRequest updateUsersRequest = UpdateUsersRequest.builder().users(usersMap).build();
     client.updateUsers(updateUsersRequest).execute();
@@ -71,7 +83,7 @@ public class ModerationTest {
     // snippet-start: BanWithReason
     BanRequest request =
         BanRequest.builder()
-            .targetUserID(testUserId)
+            .targetUserID(bannedUserId)
             .reason("spam")
             .timeout(60) // 60 minutes
             .bannedByID(testModeratorId)
@@ -206,7 +218,7 @@ public class ModerationTest {
     // First ban the user
     BanRequest banRequest =
         BanRequest.builder()
-            .targetUserID(testUserId)
+            .targetUserID(bannedUserId)
             .reason("test")
             .bannedByID(testModeratorId)
             .build();
@@ -214,7 +226,7 @@ public class ModerationTest {
 
     // snippet-start: UnbanUser
     UnbanRequest request =
-        UnbanRequest.builder().TargetUserID(testUserId).unbannedByID(testModeratorId).build();
+        UnbanRequest.builder().TargetUserID(bannedUserId).unbannedByID(testModeratorId).build();
 
     UnbanResponse response = moderation.unban(request).execute().getData();
     // snippet-end: UnbanUser

--- a/src/test/java/io/getstream/StreamErrorHandlingTest.java
+++ b/src/test/java/io/getstream/StreamErrorHandlingTest.java
@@ -107,7 +107,8 @@ class StreamErrorHandlingTest {
     StreamApiException e = assertThrows(StreamApiException.class, () -> request().execute());
     assertEquals(502, e.getStatusCode(), "status code preserved when body is unparseable");
     assertEquals(0, e.getCode(), "unparseable body → code 0");
-    assertEquals("failed to parse error response", e.getMessage());
+    assertEquals(
+        "failed to parse error response: unexpected server response code 502", e.getMessage());
     assertEquals("<html>bad gateway</html>", e.getRawResponseBody());
     assertNotNull(e.getCause(), "parse error preserved on cause chain");
   }


### PR DESCRIPTION
## Ticket
https://linear.app/stream/issue/CHA-4641/generated-sdks-report-the-http-status-when-the-error-body-is-not-json

## Summary
When an error body is not JSON, the SDK reported only the parse failure and hid the HTTP status. A customer on 8.0.0 saw `StreamApiException: failed to parse error response` for a 503 that the edge proxy returned as plain text, with a Jackson `JsonParseException` cause, and could not tell which status they got. `StreamException.build(Response)` now appends the status: `failed to parse error response: unexpected server response code 503`. `getStatusCode()`, `getRawResponseBody()` and the cause do not change.

The old text is still the prefix of the new message, so prefix matching and substring matching on it both keep working.

`build(ResponseBody)` keeps the old message. That overload does not receive the status, and its javadoc already tells callers to prefer `build(Response)`.

## Verification
- `./gradlew spotlessCheck`: pass.
- `./gradlew test --tests io.getstream.StreamErrorHandlingTest`: 11 tests, 0 failures.
- `./gradlew build`: the integration test classes fail on `initializationError: apiKey and apiSecret are required`, which needs credentials. The base commit behaves the same.

## Also in this PR: a red test on main, not caused by this change
`ModerationTest > Can flag activity` and `Can check activity content` fail on `main` too, in the scheduled run of 2026-08-10 (run 31375353948, same `464 tests completed, 2 failed, 23 skipped`). Last green run on main was 2026-08-03.

Cause: `testBanWithReason` globally banned the shared `testUserId` for 60 minutes, and a banned user cannot add an activity. The two tests above create an activity as that user, so they failed whenever JUnit ran them after the ban test. The ban and unban tests now target a dedicated `bannedUserId`, which keeps the ban out of the shared fixture.

The doc snippets keep the same shape; only the target user variable changes.
